### PR TITLE
Cast to string when calling rawurlencode within Regex router

### DIFF
--- a/src/Http/Regex.php
+++ b/src/Http/Regex.php
@@ -155,7 +155,7 @@ class Regex implements RouteInterface
             $spec = '%' . $key . '%';
 
             if (strpos($url, $spec) !== false) {
-                $url = str_replace($spec, rawurlencode($value), $url);
+                $url = str_replace($spec, rawurlencode((string) $value), $url);
 
                 $this->assembledParams[] = $key;
             }

--- a/test/Http/RegexTest.php
+++ b/test/Http/RegexTest.php
@@ -64,6 +64,12 @@ class RegexTest extends TestCase
                 null,
                 ['bar' => 'bar', 'baz' => 'baz']
             ],
+            'params-contain-non-string-scalar-values' => [
+                new Regex('/id/(?<id>\d+)/scale/(?<scale>\d+\.\d+)', '/id/%id%/scale/%scale%'),
+                '/id/42/scale/4.2',
+                null,
+                ['id' => 42, 'scale' => 4.2]
+            ],
         ];
     }
 


### PR DESCRIPTION
The `Regex` router, when assembling a URL, was not casting values to string when calling `rawurlencode()`, leading to a `TypeError` in PHP 8.

This patch now uses an explicit cast when calling the function.

Fixes #14
