### PR TITLE
Fix type issue in Hostname route uncovered by strict types

### DIFF
--- a/src/Http/Hostname.php
+++ b/src/Http/Hostname.php
@@ -13,7 +13,10 @@ namespace Laminas\Router\Http;
 use Laminas\Router\Exception;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
+use Laminas\Uri\UriInterface;
 use Traversable;
+
+use function preg_match;
 
 /**
  * Hostname route.
@@ -285,16 +288,17 @@ class Hostname implements RouteInterface
     public function match(Request $request)
     {
         if (! method_exists($request, 'getUri')) {
-            return;
+            return null;
         }
 
+        /** @var UriInterface $uri */
         $uri  = $request->getUri();
-        $host = $uri->getHost();
+        $host = $uri->getHost() ?? '';
 
         $result = preg_match('(^' . $this->regex . '$)', $host, $matches);
 
         if (! $result) {
-            return;
+            return null;
         }
 
         $params = [];

--- a/test/Http/HostnameTest.php
+++ b/test/Http/HostnameTest.php
@@ -214,6 +214,35 @@ class HostnameTest extends TestCase
         $this->assertNull($route->match($request));
     }
 
+    public function testNoMatchWithRelativeUri(): void
+    {
+        $route   = new Hostname('example.com');
+        $request = new Request();
+        $request->setUri('/relative/path');
+
+        self::assertNull($route->match($request));
+    }
+
+    public function testNoMatchWithPlaceholderOnRelativeUri(): void
+    {
+        $route   = new Hostname(':domain');
+        $request = new Request();
+        $request->setUri('/relative/path');
+
+        self::assertNull($route->match($request));
+    }
+
+    public function testMatchesRelativeUriWithFullyOptionalDefinition(): void
+    {
+        $route   = new Hostname('[:domain]');
+        $request = new Request();
+        $request->setUri('/relative/path');
+
+        $match = $route->match($request);
+        self::assertInstanceOf(RouteMatch::class, $match);
+        self::assertArrayNotHasKey('domain', $match->getParams());
+    }
+
     public function testAssemblingWithMissingParameter()
     {
         $route = new Hostname(':foo.example.com');


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
Introduction of strict types uncovered type issue in Hostname route where it is trying to match `null` hostname on relative uri.

Fixes #20 