### PR TITLE
Update to laminas-coding-standard v2.2 series

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "laminas/laminas-stdlib": "^3.6"
     },
     "require-dev": {
-        "laminas/laminas-coding-standard": "~1.0.0",
+        "laminas/laminas-coding-standard": "~2.2.1",
         "laminas/laminas-i18n": "^2.7.4",
         "phpunit/phpunit": "^9.5.5",
         "psalm/plugin-phpunit": "^0.15.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e5abf6ed97849921ee006a9f0c692691",
+    "content-hash": "e2b81e7cd99ecb59a03087bffd8b59eb",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -1017,6 +1017,76 @@
             "time": "2021-07-31T17:03:58+00:00"
         },
         {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2020-12-07T18:04:37+00:00"
+        },
+        {
             "name": "dnoegel/php-xdg-base-dir",
             "version": "v0.1.1",
             "source": {
@@ -1225,31 +1295,36 @@
         },
         {
             "name": "laminas/laminas-coding-standard",
-            "version": "1.0.0",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-coding-standard.git",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539"
+                "reference": "c953ecb1d37034f4aa326046e2c24a10fe0a2845"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/08880ce2fbfe62d471cd3cb766a91da630b32539",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539",
+                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/c953ecb1d37034f4aa326046e2c24a10fe0a2845",
+                "reference": "c953ecb1d37034f4aa326046e2c24a10fe0a2845",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "squizlabs/php_codesniffer": "^2.7"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.3 || ~8.0.0",
+                "slevomat/coding-standard": "^6.4.1",
+                "squizlabs/php_codesniffer": "^3.5.8",
+                "webimpress/coding-standard": "^1.1.6"
             },
-            "replace": {
-                "zendframework/zend-coding-standard": "self.version"
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "LaminasCodingStandard\\": "src/LaminasCodingStandard/"
+                }
             },
-            "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
-            "description": "Laminas coding standard",
+            "description": "Laminas Coding Standard",
             "homepage": "https://laminas.dev",
             "keywords": [
                 "Coding Standard",
@@ -1263,7 +1338,13 @@
                 "rss": "https://github.com/laminas/laminas-coding-standard/releases.atom",
                 "source": "https://github.com/laminas/laminas-coding-standard"
             },
-            "time": "2019-12-31T16:28:26+00:00"
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-05-17T17:39:41+00:00"
         },
         {
             "name": "laminas/laminas-i18n",
@@ -1904,6 +1985,59 @@
                 "source": "https://github.com/phpspec/prophecy/tree/1.14.0"
             },
             "time": "2021-09-10T09:02:12+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "0.4.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/98a088b17966bdf6ee25c8a4b634df313d8aa531",
+                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "consistence/coding-standard": "^3.5",
+                "ergebnis/composer-normalize": "^2.0.2",
+                "jakub-onderka/php-parallel-lint": "^0.9.2",
+                "phing/phing": "^2.16.0",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.12.26",
+                "phpstan/phpstan-strict-rules": "^0.12",
+                "phpunit/phpunit": "^6.3",
+                "slevomat/coding-standard": "^4.7.2",
+                "symfony/process": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/master"
+            },
+            "time": "2020-08-03T20:32:43+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3401,64 +3535,98 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "2.9.2",
+            "name": "slevomat/coding-standard",
+            "version": "6.4.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745"
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/2acf168de78487db620ab4bc524135a13cfe6745",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/696dcca217d0c9da2c40d02731526c1e25b65346",
+                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpdoc-parser": "0.4.5 - 0.4.9",
+                "squizlabs/php_codesniffer": "^3.5.6"
+            },
+            "require-dev": {
+                "phing/phing": "2.16.3",
+                "php-parallel-lint/php-parallel-lint": "1.2.0",
+                "phpstan/phpstan": "0.12.48",
+                "phpstan/phpstan-deprecation-rules": "0.12.5",
+                "phpstan/phpstan-phpunit": "0.12.16",
+                "phpstan/phpstan-strict-rules": "0.12.5",
+                "phpunit/phpunit": "7.5.20|8.5.5|9.4.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/6.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-05T12:39:37+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/f268ca40d54617c6e06757f83f699775c9b3ff2e",
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=5.1.2"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
-                "scripts/phpcs",
-                "scripts/phpcbf"
+                "bin/phpcs",
+                "bin/phpcbf"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "3.x-dev"
                 }
-            },
-            "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Fixer.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3471,7 +3639,7 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
@@ -3481,7 +3649,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2018-11-07T22:31:41+00:00"
+            "time": "2021-10-11T04:00:11+00:00"
         },
         {
             "name": "symfony/console",
@@ -4451,6 +4619,61 @@
                 "source": "https://github.com/vimeo/psalm/tree/4.10.0"
             },
             "time": "2021-09-04T21:00:09+00:00"
+        },
+        {
+            "name": "webimpress/coding-standard",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/coding-standard.git",
+                "reference": "8f4a220de33f471a8101836f7ec72b852c3f9f03"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/8f4a220de33f471a8101836f7ec72b852c3f9f03",
+                "reference": "8f4a220de33f471a8101836f7ec72b852c3f9f03",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0",
+                "squizlabs/php_codesniffer": "^3.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5.4"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "dev-master": "1.2.x-dev",
+                "dev-develop": "1.3.x-dev"
+            },
+            "autoload": {
+                "psr-4": {
+                    "WebimpressCodingStandard\\": "src/WebimpressCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Webimpress Coding Standard",
+            "keywords": [
+                "Coding Standard",
+                "PSR-2",
+                "phpcs",
+                "psr-12",
+                "webimpress"
+            ],
+            "support": {
+                "issues": "https://github.com/webimpress/coding-standard/issues",
+                "source": "https://github.com/webimpress/coding-standard/tree/1.2.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/michalbundyra",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-04-12T12:51:27+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0"?>
-<ruleset name="Laminas coding standard">
-    <rule ref="./vendor/laminas/laminas-coding-standard/ruleset.xml"/>
-
-    <!-- Paths to check -->
-    <file>src</file>
-    <file>test</file>
-</ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<ruleset
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="./vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+    <arg name="basepath" value="."/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
+
+    <!-- Show progress -->
+    <arg value="p"/>
+
+    <!-- Paths to check -->
+    <file>src</file>
+    <file>test</file>
+
+    <!-- Include all rules from Laminas Coding Standard -->
+    <rule ref="LaminasCodingStandard"/>
+</ruleset>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -114,9 +114,9 @@
     </UnsafeInstantiation>
   </file>
   <file src="src/Http/HttpRouterFactory.php">
-    <DeprecatedInterface occurrences="1">
-      <code>HttpRouterFactory</code>
-    </DeprecatedInterface>
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$this-&gt;createRouter($class, $config, $container)</code>
+    </LessSpecificReturnStatement>
     <MixedArgument occurrences="1">
       <code>$config</code>
     </MixedArgument>
@@ -127,12 +127,9 @@
       <code>$config</code>
       <code>$config</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MoreSpecificReturnType occurrences="1">
       <code>RouteStackInterface</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;createRouter($class, $config, $container)</code>
-    </MixedReturnStatement>
+    </MoreSpecificReturnType>
   </file>
   <file src="src/Http/Literal.php">
     <DocblockTypeContradiction occurrences="1">
@@ -300,6 +297,7 @@
       <code>$matches[0]</code>
       <code>$options['constraints']</code>
       <code>$options['defaults']</code>
+      <code>$options['has_child'] ?? false</code>
       <code>$options['route']</code>
       <code>$part[1]</code>
       <code>$part[1]</code>
@@ -308,7 +306,6 @@
       <code>$path</code>
       <code>$path</code>
       <code>$textDomain</code>
-      <code>isset($options['has_child']) ? $options['has_child'] : false</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="18">
       <code>$part[0]</code>
@@ -522,47 +519,20 @@
     </UndefinedMethod>
   </file>
   <file src="src/Http/Wildcard.php">
-    <DocblockTypeContradiction occurrences="2">
-      <code>$this-&gt;keyValueDelimiter === $this-&gt;paramDelimiter</code>
+    <DocblockTypeContradiction occurrences="1">
       <code>is_array($options)</code>
     </DocblockTypeContradiction>
-    <InvalidArgument occurrences="1">
-      <code>$this-&gt;paramDelimiter</code>
-    </InvalidArgument>
-    <InvalidCast occurrences="1">
-      <code>$this-&gt;paramDelimiter</code>
-    </InvalidCast>
-    <InvalidOperand occurrences="1">
-      <code>$this-&gt;paramDelimiter</code>
-    </InvalidOperand>
-    <InvalidPropertyAssignmentValue occurrences="1">
-      <code>$paramDelimiter</code>
-    </InvalidPropertyAssignmentValue>
-    <MixedArgument occurrences="12">
+    <MixedArgument occurrences="5">
       <code>$options['defaults']</code>
       <code>$options['key_value_delimiter']</code>
       <code>$options['param_delimiter']</code>
-      <code>$param</code>
-      <code>$params</code>
-      <code>$params</code>
-      <code>$params</code>
-      <code>$params</code>
-      <code>$params[$i + 1]</code>
-      <code>$params[$i]</code>
       <code>$path</code>
       <code>$path</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$key</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="3">
-      <code>$params[$i + 1]</code>
-      <code>$params[$i]</code>
-      <code>$params[0]</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="4">
-      <code>$param</code>
-      <code>$params</code>
+    <MixedAssignment occurrences="2">
       <code>$path</code>
       <code>$uri</code>
     </MixedAssignment>
@@ -577,19 +547,9 @@
     <DeprecatedInterface occurrences="1">
       <code>RouteInvokableFactory</code>
     </DeprecatedInterface>
-    <MissingParamType occurrences="2">
-      <code>$normalizedName</code>
-      <code>$routeName</code>
-    </MissingParamType>
     <MissingReturnType occurrences="1">
       <code>setCreationOptions</code>
     </MissingReturnType>
-    <MixedArgument occurrences="1">
-      <code>$routeName</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$routeName</code>
-    </MixedAssignment>
     <ParamNameMismatch occurrences="8">
       <code>$container</code>
       <code>$container</code>
@@ -607,7 +567,9 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/RoutePluginManager.php">
-    <DocblockTypeContradiction occurrences="1"/>
+    <DocblockTypeContradiction occurrences="1">
+      <code>gettype($instance)</code>
+    </DocblockTypeContradiction>
     <ImplementedReturnTypeMismatch occurrences="1">
       <code>void</code>
     </ImplementedReturnTypeMismatch>
@@ -634,17 +596,11 @@
     <NonInvariantDocblockPropertyType occurrences="1">
       <code>$instanceOf</code>
     </NonInvariantDocblockPropertyType>
-    <RedundantConditionGivenDocblockType occurrences="1"/>
-  </file>
-  <file src="src/RoutePluginManagerFactory.php">
-    <DeprecatedInterface occurrences="1">
-      <code>RoutePluginManagerFactory</code>
-    </DeprecatedInterface>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>is_object($instance)</code>
+    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/RouterConfigTrait.php">
-    <MissingReturnType occurrences="1">
-      <code>createRouter</code>
-    </MissingReturnType>
     <MixedArgument occurrences="1">
       <code>$config['router_class']</code>
     </MixedArgument>
@@ -652,11 +608,11 @@
       <code>$config['route_plugins']</code>
       <code>$routePluginManager</code>
     </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>RouteInterface</code>
+    </MixedInferredReturnType>
   </file>
   <file src="src/RouterFactory.php">
-    <DeprecatedInterface occurrences="1">
-      <code>RouterFactory</code>
-    </DeprecatedInterface>
     <MixedInferredReturnType occurrences="1">
       <code>RouteStackInterface</code>
     </MixedInferredReturnType>
@@ -728,36 +684,18 @@
     </UnsafeInstantiation>
   </file>
   <file src="test/FactoryTester.php">
-    <InvalidDocblockParamName occurrences="1">
-      <code>$className</code>
-    </InvalidDocblockParamName>
-    <MissingParamType occurrences="1">
-      <code>$classname</code>
-    </MissingParamType>
     <MixedArgument occurrences="1">
       <code>$exceptionMessage</code>
     </MixedArgument>
     <MixedAssignment occurrences="1">
       <code>$exceptionMessage</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="4">
-      <code>$classname::factory($options)</code>
-      <code>$classname::factory($testOptions)</code>
-      <code>$classname::factory(0)</code>
-      <code>$classname::factory(new ArrayIterator($options))</code>
-    </MixedMethodCall>
   </file>
   <file src="test/Http/ChainTest.php">
     <DeprecatedClass occurrences="1">
       <code>Wildcard::class</code>
     </DeprecatedClass>
-    <DocblockTypeContradiction occurrences="1">
-      <code>$offset === null</code>
-    </DocblockTypeContradiction>
-    <MissingReturnType occurrences="6">
-      <code>getRoute</code>
-      <code>getRouteWithOptionalParam</code>
-      <code>routeProvider</code>
+    <MissingReturnType occurrences="3">
       <code>testAssembling</code>
       <code>testFactory</code>
       <code>testMatching</code>
@@ -769,16 +707,12 @@
       <code>$result</code>
       <code>$value</code>
     </MixedAssignment>
-    <RedundantConditionGivenDocblockType occurrences="1">
-      <code>$offset !== null</code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="test/Http/HostnameTest.php">
     <DuplicateArrayKey occurrences="1">
       <code>'foo' =&gt; 'bat'</code>
     </DuplicateArrayKey>
-    <MissingReturnType occurrences="8">
-      <code>routeProvider</code>
+    <MissingReturnType occurrences="7">
       <code>testAssembling</code>
       <code>testAssemblingWithMissingParameter</code>
       <code>testFactory</code>
@@ -811,11 +745,7 @@
     </UndefinedThisPropertyAssignment>
   </file>
   <file src="test/Http/LiteralTest.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>$offset === null</code>
-    </DocblockTypeContradiction>
-    <MissingReturnType occurrences="7">
-      <code>routeProvider</code>
+    <MissingReturnType occurrences="6">
       <code>testAssembling</code>
       <code>testEmptyLiteral</code>
       <code>testFactory</code>
@@ -826,23 +756,13 @@
     <MixedAssignment occurrences="1">
       <code>$result</code>
     </MixedAssignment>
-    <RedundantConditionGivenDocblockType occurrences="1">
-      <code>$offset !== null</code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="test/Http/MethodTest.php">
-    <MissingParamType occurrences="1">
-      <code>$verb</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="4">
-      <code>routeProvider</code>
+    <MissingReturnType occurrences="3">
       <code>testFactory</code>
       <code>testMatching</code>
       <code>testNoMatchWithoutVerb</code>
     </MissingReturnType>
-    <MixedArgument occurrences="1">
-      <code>$verb</code>
-    </MixedArgument>
   </file>
   <file src="test/Http/PartTest.php">
     <DeprecatedClass occurrences="7">
@@ -854,15 +774,8 @@
       <code>Wildcard::class</code>
       <code>Wildcard::class</code>
     </DeprecatedClass>
-    <DocblockTypeContradiction occurrences="1">
-      <code>$offset === null</code>
-    </DocblockTypeContradiction>
     <DuplicateArrayKey occurrences="1"/>
-    <MissingReturnType occurrences="14">
-      <code>getRoute</code>
-      <code>getRouteAlternative</code>
-      <code>getRoutePlugins</code>
-      <code>routeProvider</code>
+    <MissingReturnType occurrences="10">
       <code>testAssembleNonTerminatedRoute</code>
       <code>testAssembling</code>
       <code>testBaseRouteMayNotBePartRoute</code>
@@ -874,30 +787,19 @@
       <code>testPartRouteMarkedAsMayTerminateButWithQueryRouteChildWillMatchChildRoute</code>
       <code>testPartRouteMarkedAsMayTerminateCanMatchWhenQueryStringPresent</code>
     </MissingReturnType>
-    <MixedArgument occurrences="2">
-      <code>self::getRoutePlugins()</code>
-      <code>self::getRoutePlugins()</code>
-    </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$key</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment occurrences="4">
       <code>$query</code>
       <code>$query</code>
       <code>$result</code>
-      <code>$route</code>
-      <code>$route</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="4">
-      <code>assemble</code>
-      <code>assemble</code>
-      <code>getAssembledParams</code>
-      <code>match</code>
-    </MixedMethodCall>
-    <RedundantConditionGivenDocblockType occurrences="1">
-      <code>$offset !== null</code>
-    </RedundantConditionGivenDocblockType>
+    <PossiblyInvalidArgument occurrences="2">
+      <code>testAssembling</code>
+      <code>testMatching</code>
+    </PossiblyInvalidArgument>
     <UnusedVariable occurrences="3">
       <code>$query</code>
       <code>$query</code>
@@ -905,27 +807,16 @@
     </UnusedVariable>
   </file>
   <file src="test/Http/PlaceholderTest.php">
-    <MissingPropertyType occurrences="1">
-      <code>$routeConfig</code>
-    </MissingPropertyType>
-    <MissingReturnType occurrences="6">
-      <code>placeholderProvider</code>
+    <MissingReturnType occurrences="5">
       <code>testAssembling</code>
       <code>testFactory</code>
       <code>testGetAssembledParams</code>
       <code>testMatch</code>
       <code>testPlaceholderDefault</code>
     </MissingReturnType>
-    <MixedArgument occurrences="1">
-      <code>self::$routeConfig</code>
-    </MixedArgument>
   </file>
   <file src="test/Http/RegexTest.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>$offset === null</code>
-    </DocblockTypeContradiction>
-    <MissingReturnType occurrences="8">
-      <code>routeProvider</code>
+    <MissingReturnType occurrences="7">
       <code>testAssembling</code>
       <code>testEncodedDecode</code>
       <code>testFactory</code>
@@ -945,9 +836,6 @@
       <code>getParam</code>
       <code>getParam</code>
     </PossiblyNullReference>
-    <RedundantConditionGivenDocblockType occurrences="1">
-      <code>$offset !== null</code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="test/Http/RouteMatchTest.php">
     <MissingReturnType occurrences="6">
@@ -976,18 +864,14 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$exceptionName</code>
     </ArgumentTypeCoercion>
-    <DocblockTypeContradiction occurrences="2">
-      <code>$offset === null</code>
+    <DocblockTypeContradiction occurrences="1">
       <code>$offset === null</code>
     </DocblockTypeContradiction>
     <InvalidScalarArgument occurrences="2">
       <code>$offset</code>
       <code>$offset</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="17">
-      <code>l10nRouteProvider</code>
-      <code>parseExceptionsProvider</code>
-      <code>routeProvider</code>
+    <MissingReturnType occurrences="14">
       <code>testAssembling</code>
       <code>testAssemblingWithExistingChild</code>
       <code>testAssemblingWithL10n</code>
@@ -1038,12 +922,15 @@
       <code>null</code>
       <code>null</code>
     </NullArgument>
+    <PossiblyInvalidArgument occurrences="2">
+      <code>testAssembling</code>
+      <code>testMatching</code>
+    </PossiblyInvalidArgument>
     <PossiblyNullReference occurrences="2">
       <code>getParam</code>
       <code>getParam</code>
     </PossiblyNullReference>
-    <RedundantConditionGivenDocblockType occurrences="2">
-      <code>$offset !== null</code>
+    <RedundantConditionGivenDocblockType occurrences="1">
       <code>$offset !== null</code>
     </RedundantConditionGivenDocblockType>
     <UndefinedMethod occurrences="3">
@@ -1161,11 +1048,8 @@
       <code>new Wildcard()</code>
       <code>new Wildcard()</code>
     </DeprecatedClass>
-    <DocblockTypeContradiction occurrences="1">
-      <code>$offset === null</code>
-    </DocblockTypeContradiction>
-    <MissingReturnType occurrences="9">
-      <code>routeProvider</code>
+    <LessSpecificReturnStatement occurrences="1"/>
+    <MissingReturnType occurrences="8">
       <code>testAssembling</code>
       <code>testEncodedDecode</code>
       <code>testFactory</code>
@@ -1183,16 +1067,14 @@
       <code>$result</code>
       <code>$value</code>
     </MixedAssignment>
+    <MoreSpecificReturnType occurrences="1"/>
     <PossiblyNullReference occurrences="2">
       <code>getParam</code>
       <code>getParam</code>
     </PossiblyNullReference>
-    <RedundantConditionGivenDocblockType occurrences="1">
-      <code>$offset !== null</code>
-    </RedundantConditionGivenDocblockType>
     <UndefinedClass occurrences="2">
-      <code>\Some\ConnectMiddleware</code>
-      <code>\Some\Handler</code>
+      <code>ConnectMiddleware</code>
+      <code>Handler</code>
     </UndefinedClass>
   </file>
   <file src="test/PriorityListTest.php">
@@ -1330,20 +1212,15 @@
     </UnsafeInstantiation>
   </file>
   <file src="test/TestAsset/Router.php">
-    <ImplementedReturnTypeMismatch occurrences="2">
+    <ImplementedReturnTypeMismatch occurrences="1">
       <code>RouteMatch|null</code>
-      <code>void</code>
     </ImplementedReturnTypeMismatch>
-    <InvalidReturnStatement occurrences="1">
-      <code>new static()</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType occurrences="6">
+    <InvalidReturnType occurrences="5">
       <code>RouteStackInterface</code>
       <code>RouteStackInterface</code>
       <code>RouteStackInterface</code>
       <code>RouteStackInterface</code>
       <code>mixed</code>
-      <code>void</code>
     </InvalidReturnType>
     <UndefinedDocblockClass occurrences="1">
       <code>RouteMatch|null</code>

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -1,14 +1,10 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router;
+
+use Zend\Router\Http\TreeRouteStack;
 
 /**
  * Provide base configuration for using the component.
@@ -28,7 +24,7 @@ class ConfigProvider
     public function __invoke()
     {
         return [
-            'dependencies' => $this->getDependencyConfig(),
+            'dependencies'  => $this->getDependencyConfig(),
             'route_manager' => $this->getRouteManagerConfig(),
         ];
     }
@@ -41,20 +37,20 @@ class ConfigProvider
     public function getDependencyConfig()
     {
         return [
-            'aliases' => [
-                'HttpRouter' => Http\TreeRouteStack::class,
-                'router' => RouteStackInterface::class,
-                'Router' => RouteStackInterface::class,
+            'aliases'   => [
+                'HttpRouter'         => Http\TreeRouteStack::class,
+                'router'             => RouteStackInterface::class,
+                'Router'             => RouteStackInterface::class,
                 'RoutePluginManager' => RoutePluginManager::class,
 
                 // Legacy Zend Framework aliases
-                \Zend\Router\Http\TreeRouteStack::class => Http\TreeRouteStack::class,
-                \Zend\Router\RoutePluginManager::class => RoutePluginManager::class,
+                TreeRouteStack::class                   => Http\TreeRouteStack::class,
+                \Zend\Router\RoutePluginManager::class  => RoutePluginManager::class,
                 \Zend\Router\RouteStackInterface::class => RouteStackInterface::class,
             ],
             'factories' => [
                 Http\TreeRouteStack::class => Http\HttpRouterFactory::class,
-                RoutePluginManager::class => RoutePluginManagerFactory::class,
+                RoutePluginManager::class  => RoutePluginManagerFactory::class,
                 RouteStackInterface::class => RouterFactory::class,
             ],
         ];

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router\Exception;

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router\Exception;

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router\Exception;

--- a/src/Http/Chain.php
+++ b/src/Http/Chain.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router\Http;
@@ -17,6 +11,16 @@ use Laminas\Router\RoutePluginManager;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
 use Traversable;
+
+use function array_diff_key;
+use function array_flip;
+use function array_reverse;
+use function end;
+use function is_array;
+use function key;
+use function method_exists;
+use function sprintf;
+use function strlen;
 
 /**
  * Chain route.
@@ -41,21 +45,20 @@ class Chain extends TreeRouteStack implements RouteInterface
      * Create a new part route.
      *
      * @param  array              $routes
-     * @param  RoutePluginManager $routePlugins
-     * @param  ArrayObject|null   $prototypes
      */
-    public function __construct(array $routes, RoutePluginManager $routePlugins, ArrayObject $prototypes = null)
+    public function __construct(array $routes, RoutePluginManager $routePlugins, ?ArrayObject $prototypes = null)
     {
-        $this->chainRoutes         = array_reverse($routes);
-        $this->routePluginManager  = $routePlugins;
-        $this->routes              = new PriorityList();
-        $this->prototypes          = $prototypes;
+        $this->chainRoutes        = array_reverse($routes);
+        $this->routePluginManager = $routePlugins;
+        $this->routes             = new PriorityList();
+        $this->prototypes         = $prototypes;
     }
 
     /**
      * factory(): defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::factory()
+     *
      * @param  mixed $options
      * @throws Exception\InvalidArgumentException
      * @return Part
@@ -98,7 +101,7 @@ class Chain extends TreeRouteStack implements RouteInterface
      * match(): defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::match()
-     * @param  Request  $request
+     *
      * @param  int|null $pathOffset
      * @param  array    $options
      * @return RouteMatch|null
@@ -147,6 +150,7 @@ class Chain extends TreeRouteStack implements RouteInterface
      * assemble(): Defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::assemble()
+     *
      * @param  array $params
      * @param  array $options
      * @return mixed
@@ -169,12 +173,12 @@ class Chain extends TreeRouteStack implements RouteInterface
         foreach ($routes as $key => $route) {
             /** @var RouteInterface $route */
             $chainOptions = $options;
-            $hasChild     = isset($options['has_child']) ? $options['has_child'] : false;
+            $hasChild     = $options['has_child'] ?? false;
 
-            $chainOptions['has_child'] = ($hasChild || $key !== $lastRouteKey);
+            $chainOptions['has_child'] = $hasChild || $key !== $lastRouteKey;
 
-            $path   .= $route->assemble($params, $chainOptions);
-            $params  = array_diff_key($params, array_flip($route->getAssembledParams()));
+            $path  .= $route->assemble($params, $chainOptions);
+            $params = array_diff_key($params, array_flip($route->getAssembledParams()));
 
             $this->assembledParams += $route->getAssembledParams();
         }
@@ -186,6 +190,7 @@ class Chain extends TreeRouteStack implements RouteInterface
      * getAssembledParams(): defined by RouteInterface interface.
      *
      * @see    RouteInterface::getAssembledParams
+     *
      * @return array
      */
     public function getAssembledParams()

--- a/src/Http/Hostname.php
+++ b/src/Http/Hostname.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router\Http;
@@ -16,7 +10,14 @@ use Laminas\Stdlib\RequestInterface as Request;
 use Laminas\Uri\UriInterface;
 use Traversable;
 
+use function array_merge;
+use function count;
+use function is_array;
+use function method_exists;
 use function preg_match;
+use function preg_quote;
+use function sprintf;
+use function strlen;
 
 /**
  * Hostname route.
@@ -76,6 +77,7 @@ class Hostname implements RouteInterface
      * factory(): defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::factory()
+     *
      * @param  array|Traversable $options
      * @return Hostname
      * @throws Exception\InvalidArgumentException
@@ -133,25 +135,27 @@ class Hostname implements RouteInterface
             }
 
             if ($matches['token'] === ':') {
-                if (! preg_match(
-                    '(\G(?P<name>[^:.{\[\]]+)(?:{(?P<delimiters>[^}]+)})?:?)',
-                    $def,
-                    $matches,
-                    0,
-                    $currentPos
-                )) {
+                if (
+                    ! preg_match(
+                        '(\G(?P<name>[^:.{\[\]]+)(?:{(?P<delimiters>[^}]+)})?:?)',
+                        $def,
+                        $matches,
+                        0,
+                        $currentPos
+                    )
+                ) {
                     throw new Exception\RuntimeException('Found empty parameter name');
                 }
 
                 $levelParts[$level][] = [
                     'parameter',
                     $matches['name'],
-                    isset($matches['delimiters']) ? $matches['delimiters'] : null
+                    $matches['delimiters'] ?? null,
                 ];
 
                 $currentPos += strlen($matches[0]);
             } elseif ($matches['token'] === '[') {
-                $levelParts[$level][] = ['optional', []];
+                $levelParts[$level][]   = ['optional', []];
                 $levelParts[$level + 1] = &$levelParts[$level][count($levelParts[$level]) - 1][1];
 
                 $level++;
@@ -247,7 +251,8 @@ class Hostname implements RouteInterface
                         }
 
                         return '';
-                    } elseif (! $isOptional
+                    } elseif (
+                        ! $isOptional
                         || ! isset($this->defaults[$part[1]])
                         || $this->defaults[$part[1]] !== $mergedParams[$part[1]]
                     ) {
@@ -282,7 +287,7 @@ class Hostname implements RouteInterface
      * match(): defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::match()
-     * @param  Request $request
+     *
      * @return RouteMatch|null
      */
     public function match(Request $request)
@@ -316,6 +321,7 @@ class Hostname implements RouteInterface
      * assemble(): Defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::assemble()
+     *
      * @param  array $params
      * @param  array $options
      * @return mixed
@@ -342,6 +348,7 @@ class Hostname implements RouteInterface
      * getAssembledParams(): defined by RouteInterface interface.
      *
      * @see    RouteInterface::getAssembledParams
+     *
      * @return array
      */
     public function getAssembledParams()

--- a/src/Http/HttpRouterFactory.php
+++ b/src/Http/HttpRouterFactory.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router\Http;
@@ -16,6 +10,7 @@ use Laminas\Router\RouteStackInterface;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 
+/** @psalm-suppress DeprecatedInterface */
 class HttpRouterFactory implements FactoryInterface
 {
     use RouterConfigTrait;
@@ -27,18 +22,17 @@ class HttpRouterFactory implements FactoryInterface
      * to instantiate the router. Uses the TreeRouteStack implementation by
      * default.
      *
-     * @param  ContainerInterface $container
      * @param  string $name
      * @param  null|array $options
      * @return RouteStackInterface
      */
-    public function __invoke(ContainerInterface $container, $name, array $options = null)
+    public function __invoke(ContainerInterface $container, $name, ?array $options = null)
     {
         $config = $container->has('config') ? $container->get('config') : [];
 
         // Defaults
         $class  = TreeRouteStack::class;
-        $config = isset($config['router']) ? $config['router'] : [];
+        $config = $config['router'] ?? [];
 
         return $this->createRouter($class, $config, $container);
     }

--- a/src/Http/Literal.php
+++ b/src/Http/Literal.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router\Http;
@@ -14,6 +8,12 @@ use Laminas\Router\Exception;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
 use Traversable;
+
+use function is_array;
+use function method_exists;
+use function sprintf;
+use function strlen;
+use function strpos;
 
 /**
  * Literal route.
@@ -50,6 +50,7 @@ class Literal implements RouteInterface
      * factory(): defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::factory()
+     *
      * @param  array|Traversable $options
      * @return Literal
      * @throws Exception\InvalidArgumentException
@@ -80,14 +81,14 @@ class Literal implements RouteInterface
      * match(): defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::match()
-     * @param  Request      $request
+     *
      * @param  integer|null $pathOffset
      * @return RouteMatch|null
      */
     public function match(Request $request, $pathOffset = null)
     {
         if (! method_exists($request, 'getUri')) {
-            return;
+            return null;
         }
 
         $uri  = $request->getUri();
@@ -100,20 +101,21 @@ class Literal implements RouteInterface
                 }
             }
 
-            return;
+            return null;
         }
 
         if ($path === $this->route) {
             return new RouteMatch($this->defaults, strlen($this->route));
         }
 
-        return;
+        return null;
     }
 
     /**
      * assemble(): Defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::assemble()
+     *
      * @param  array $params
      * @param  array $options
      * @return mixed
@@ -127,6 +129,7 @@ class Literal implements RouteInterface
      * getAssembledParams(): defined by RouteInterface interface.
      *
      * @see    RouteInterface::getAssembledParams
+     *
      * @return array
      */
     public function getAssembledParams()

--- a/src/Http/Method.php
+++ b/src/Http/Method.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router\Http;
@@ -14,6 +8,14 @@ use Laminas\Router\Exception;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
 use Traversable;
+
+use function array_map;
+use function explode;
+use function in_array;
+use function is_array;
+use function method_exists;
+use function sprintf;
+use function strtoupper;
 
 /**
  * Method route.
@@ -50,6 +52,7 @@ class Method implements RouteInterface
      * factory(): defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::factory()
+     *
      * @param  array|Traversable $options
      * @return Method
      * @throws Exception\InvalidArgumentException
@@ -80,13 +83,13 @@ class Method implements RouteInterface
      * match(): defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::match()
-     * @param  Request $request
+     *
      * @return RouteMatch|null
      */
     public function match(Request $request)
     {
         if (! method_exists($request, 'getMethod')) {
-            return;
+            return null;
         }
 
         $requestVerb = strtoupper($request->getMethod());
@@ -97,13 +100,14 @@ class Method implements RouteInterface
             return new RouteMatch($this->defaults);
         }
 
-        return;
+        return null;
     }
 
     /**
      * assemble(): Defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::assemble()
+     *
      * @param  array $params
      * @param  array $options
      * @return mixed
@@ -118,6 +122,7 @@ class Method implements RouteInterface
      * getAssembledParams(): defined by RouteInterface interface.
      *
      * @see    RouteInterface::getAssembledParams
+     *
      * @return array
      */
     public function getAssembledParams()

--- a/src/Http/Part.php
+++ b/src/Http/Part.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router\Http;
@@ -17,6 +11,13 @@ use Laminas\Router\RoutePluginManager;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
 use Traversable;
+
+use function array_diff_key;
+use function array_flip;
+use function is_array;
+use function method_exists;
+use function sprintf;
+use function strlen;
 
 /**
  * Part route.
@@ -49,17 +50,15 @@ class Part extends TreeRouteStack implements RouteInterface
      *
      * @param  mixed              $route
      * @param  bool               $mayTerminate
-     * @param  RoutePluginManager $routePlugins
      * @param  array|null         $childRoutes
-     * @param  ArrayObject|null   $prototypes
      * @throws Exception\InvalidArgumentException
      */
     public function __construct(
         $route,
         $mayTerminate,
         RoutePluginManager $routePlugins,
-        array $childRoutes = null,
-        ArrayObject $prototypes = null
+        ?array $childRoutes = null,
+        ?ArrayObject $prototypes = null
     ) {
         $this->routePluginManager = $routePlugins;
 
@@ -82,6 +81,7 @@ class Part extends TreeRouteStack implements RouteInterface
      * factory(): defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::factory()
+     *
      * @param  mixed $options
      * @return Part
      * @throws Exception\InvalidArgumentException
@@ -134,7 +134,7 @@ class Part extends TreeRouteStack implements RouteInterface
      * match(): defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::match()
-     * @param  Request      $request
+     *
      * @param  integer|null $pathOffset
      * @param  array        $options
      * @return RouteMatch|null
@@ -162,7 +162,8 @@ class Part extends TreeRouteStack implements RouteInterface
                 return $match;
             }
 
-            if (isset($options['translator'])
+            if (
+                isset($options['translator'])
                 && ! isset($options['locale'])
                 && null !== ($locale = $match->getParam('locale', null))
             ) {
@@ -178,13 +179,14 @@ class Part extends TreeRouteStack implements RouteInterface
             }
         }
 
-        return;
+        return null;
     }
 
     /**
      * assemble(): Defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::assemble()
+     *
      * @param  array $params
      * @param  array $options
      * @return mixed
@@ -197,7 +199,7 @@ class Part extends TreeRouteStack implements RouteInterface
             $this->childRoutes = null;
         }
 
-        $options['has_child'] = (isset($options['name']));
+        $options['has_child'] = isset($options['name']);
 
         if (isset($options['translator']) && ! isset($options['locale']) && isset($params['locale'])) {
             $options['locale'] = $params['locale'];
@@ -216,15 +218,14 @@ class Part extends TreeRouteStack implements RouteInterface
 
         unset($options['has_child']);
         $options['only_return_path'] = true;
-        $path .= parent::assemble($params, $options);
-
-        return $path;
+        return $path . parent::assemble($params, $options);
     }
 
     /**
      * getAssembledParams(): defined by RouteInterface interface.
      *
      * @see    RouteInterface::getAssembledParams
+     *
      * @return array
      */
     public function getAssembledParams()

--- a/src/Http/Placeholder.php
+++ b/src/Http/Placeholder.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Router\Http;
 
 use Laminas\Router\Exception;
@@ -13,11 +7,15 @@ use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
 use Traversable;
 
+use function is_array;
+use function sprintf;
+
 /**
  * Placeholder route.
  */
 class Placeholder implements RouteInterface
 {
+    /** @var array */
     private $defaults;
 
     public function __construct(array $defaults)
@@ -29,6 +27,7 @@ class Placeholder implements RouteInterface
      * factory(): defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::factory()
+     *
      * @param  array|Traversable $options
      * @return Placeholder
      * @throws Exception\InvalidArgumentException
@@ -61,7 +60,7 @@ class Placeholder implements RouteInterface
      * match(): defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::match()
-     * @param  Request      $request
+     *
      * @param  integer|null $pathOffset
      * @return RouteMatch|null
      */
@@ -74,6 +73,7 @@ class Placeholder implements RouteInterface
      * assemble(): Defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::assemble()
+     *
      * @param  array $params
      * @param  array $options
      * @return mixed
@@ -87,6 +87,7 @@ class Placeholder implements RouteInterface
      * getAssembledParams(): defined by RouteInterface interface.
      *
      * @see    RouteInterface::getAssembledParams
+     *
      * @return array
      */
     public function getAssembledParams()

--- a/src/Http/Regex.php
+++ b/src/Http/Regex.php
@@ -1,19 +1,27 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router\Http;
 
 use Laminas\Router\Exception;
+use Laminas\Router\Exception\InvalidArgumentException;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
 use Traversable;
+
+use function array_merge;
+use function is_array;
+use function is_int;
+use function is_numeric;
+use function method_exists;
+use function preg_match;
+use function rawurldecode;
+use function rawurlencode;
+use function sprintf;
+use function str_replace;
+use function strlen;
+use function strpos;
 
 /**
  * Regex route.
@@ -68,9 +76,10 @@ class Regex implements RouteInterface
      * factory(): defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::factory()
+     *
      * @param  array|Traversable $options
      * @return Regex
-     * @throws \Laminas\Router\Exception\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public static function factory($options = [])
     {
@@ -101,7 +110,6 @@ class Regex implements RouteInterface
     /**
      * match(): defined by RouteInterface interface.
      *
-     * @param  Request $request
      * @param  int $pathOffset
      * @return RouteMatch|null
      */
@@ -141,6 +149,7 @@ class Regex implements RouteInterface
      * assemble(): Defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::assemble()
+     *
      * @param  array $params
      * @param  array $options
      * @return mixed
@@ -168,6 +177,7 @@ class Regex implements RouteInterface
      * getAssembledParams(): defined by RouteInterface interface.
      *
      * @see    RouteInterface::getAssembledParams
+     *
      * @return array
      */
     public function getAssembledParams()

--- a/src/Http/RouteInterface.php
+++ b/src/Http/RouteInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router\Http;

--- a/src/Http/RouteMatch.php
+++ b/src/Http/RouteMatch.php
@@ -1,16 +1,12 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router\Http;
 
 use Laminas\Router\RouteMatch as BaseRouteMatch;
+
+use function array_merge;
 
 /**
  * Part route match.
@@ -41,6 +37,7 @@ class RouteMatch extends BaseRouteMatch
      * setMatchedRouteName(): defined by BaseRouteMatch.
      *
      * @see    BaseRouteMatch::setMatchedRouteName()
+     *
      * @param  string $name
      * @return RouteMatch
      */
@@ -58,7 +55,6 @@ class RouteMatch extends BaseRouteMatch
     /**
      * Merge parameters from another match.
      *
-     * @param  RouteMatch $match
      * @return RouteMatch
      */
     public function merge(RouteMatch $match)

--- a/src/Http/Scheme.php
+++ b/src/Http/Scheme.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router\Http;
@@ -14,6 +8,10 @@ use Laminas\Router\Exception;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
 use Traversable;
+
+use function is_array;
+use function method_exists;
+use function sprintf;
 
 /**
  * Scheme route.
@@ -50,6 +48,7 @@ class Scheme implements RouteInterface
      * factory(): defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::factory()
+     *
      * @param  array|Traversable $options
      * @return Scheme
      * @throws Exception\InvalidArgumentException
@@ -80,7 +79,7 @@ class Scheme implements RouteInterface
      * match(): defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::match()
-     * @param  Request $request
+     *
      * @return RouteMatch|null
      */
     public function match(Request $request)
@@ -103,6 +102,7 @@ class Scheme implements RouteInterface
      * assemble(): Defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::assemble()
+     *
      * @param  array $params
      * @param  array $options
      * @return mixed
@@ -121,6 +121,7 @@ class Scheme implements RouteInterface
      * getAssembledParams(): defined by RouteInterface interface.
      *
      * @see    RouteInterface::getAssembledParams
+     *
      * @return array
      */
     public function getAssembledParams()

--- a/src/Http/TranslatorAwareTreeRouteStack.php
+++ b/src/Http/TranslatorAwareTreeRouteStack.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router\Http;
@@ -45,7 +39,7 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
      * match(): defined by \Laminas\Router\RouteInterface
      *
      * @see    \Laminas\Router\RouteInterface::match()
-     * @param  Request      $request
+     *
      * @param  integer|null $pathOffset
      * @param  array        $options
      * @return RouteMatch|null
@@ -67,6 +61,7 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
      * assemble(): defined by \Laminas\Router\RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::assemble()
+     *
      * @param  array $params
      * @param  array $options
      * @return mixed
@@ -90,11 +85,11 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
      * setTranslator(): defined by TranslatorAwareInterface.
      *
      * @see    TranslatorAwareInterface::setTranslator()
-     * @param  Translator $translator
+     *
      * @param  string     $textDomain
      * @return TreeRouteStack
      */
-    public function setTranslator(Translator $translator = null, $textDomain = null)
+    public function setTranslator(?Translator $translator = null, $textDomain = null)
     {
         $this->translator = $translator;
 
@@ -109,6 +104,7 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
      * getTranslator(): defined by TranslatorAwareInterface.
      *
      * @see    TranslatorAwareInterface::getTranslator()
+     *
      * @return Translator
      */
     public function getTranslator()
@@ -120,6 +116,7 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
      * hasTranslator(): defined by TranslatorAwareInterface.
      *
      * @see    TranslatorAwareInterface::hasTranslator()
+     *
      * @return bool
      */
     public function hasTranslator()
@@ -131,6 +128,7 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
      * setTranslatorEnabled(): defined by TranslatorAwareInterface.
      *
      * @see    TranslatorAwareInterface::setTranslatorEnabled()
+     *
      * @param  bool $enabled
      * @return TreeRouteStack
      */
@@ -144,6 +142,7 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
      * isTranslatorEnabled(): defined by TranslatorAwareInterface.
      *
      * @see    TranslatorAwareInterface::isTranslatorEnabled()
+     *
      * @return bool
      */
     public function isTranslatorEnabled()
@@ -155,6 +154,7 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
      * setTranslatorTextDomain(): defined by TranslatorAwareInterface.
      *
      * @see    TranslatorAwareInterface::setTranslatorTextDomain()
+     *
      * @param  string $textDomain
      * @return self
      */
@@ -169,6 +169,7 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
      * getTranslatorTextDomain(): defined by TranslatorAwareInterface.
      *
      * @see    TranslatorAwareInterface::getTranslatorTextDomain()
+     *
      * @return string
      */
     public function getTranslatorTextDomain()

--- a/src/Http/TreeRouteStack.php
+++ b/src/Http/TreeRouteStack.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router\Http;
@@ -19,6 +13,15 @@ use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
 use Laminas\Uri\Http as HttpUri;
 use Traversable;
+
+use function array_merge;
+use function explode;
+use function is_array;
+use function is_string;
+use function method_exists;
+use function rtrim;
+use function sprintf;
+use function strlen;
 
 /**
  * Tree search implementation.
@@ -53,6 +56,7 @@ class TreeRouteStack extends SimpleRouteStack
      * factory(): defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::factory()
+     *
      * @param  array|Traversable $options
      * @return SimpleRouteStack
      * @throws Exception\InvalidArgumentException
@@ -86,10 +90,10 @@ class TreeRouteStack extends SimpleRouteStack
      */
     protected function init()
     {
-        $this->prototypes = new ArrayObject;
+        $this->prototypes = new ArrayObject();
 
         (new Config([
-            'aliases' => [
+            'aliases'   => [
                 'chain'    => Chain::class,
                 'Chain'    => Chain::class,
                 'hostname' => Hostname::class,
@@ -125,7 +129,6 @@ class TreeRouteStack extends SimpleRouteStack
                 Wildcard::class => RouteInvokableFactory::class,
 
                 // v2 normalized names
-
                 'laminasmvcrouterhttpchain'    => RouteInvokableFactory::class,
                 'laminasmvcrouterhttphostname' => RouteInvokableFactory::class,
                 'laminasmvcrouterhttpliteral'  => RouteInvokableFactory::class,
@@ -143,6 +146,7 @@ class TreeRouteStack extends SimpleRouteStack
      * addRoute(): defined by RouteStackInterface interface.
      *
      * @see    RouteStackInterface::addRoute()
+     *
      * @param  string  $name
      * @param  mixed   $route
      * @param  int $priority
@@ -161,11 +165,12 @@ class TreeRouteStack extends SimpleRouteStack
      * routeFromArray(): defined by SimpleRouteStack.
      *
      * @see    SimpleRouteStack::routeFromArray()
+     *
      * @param  string|array|Traversable $specs
      * @return RouteInterface
-     * @throws Exception\InvalidArgumentException When route definition is not an array nor traversable
-     * @throws Exception\InvalidArgumentException When chain routes are not an array nor traversable
-     * @throws Exception\RuntimeException         When a generated routes does not implement the HTTP route interface
+     * @throws Exception\InvalidArgumentException When route definition is not an array nor traversable.
+     * @throws Exception\InvalidArgumentException When chain routes are not an array nor traversable.
+     * @throws Exception\RuntimeException         When a generated routes does not implement the HTTP route interface.
      */
     protected function routeFromArray($specs)
     {
@@ -211,15 +216,15 @@ class TreeRouteStack extends SimpleRouteStack
         if (isset($specs['child_routes'])) {
             $options = [
                 'route'         => $route,
-                'may_terminate' => (isset($specs['may_terminate']) && $specs['may_terminate']),
+                'may_terminate' => isset($specs['may_terminate']) && $specs['may_terminate'],
                 'child_routes'  => $specs['child_routes'],
                 'route_plugins' => $this->routePluginManager,
                 'prototypes'    => $this->prototypes,
             ];
 
-            $priority = (isset($route->priority) ? $route->priority : null);
+            $priority = $route->priority ?? null;
 
-            $route = $this->routePluginManager->get('part', $options);
+            $route           = $this->routePluginManager->get('part', $options);
             $route->priority = $priority;
         }
 
@@ -276,14 +281,14 @@ class TreeRouteStack extends SimpleRouteStack
             return $this->prototypes[$name];
         }
 
-        return;
+        return null;
     }
 
     /**
      * match(): defined by \Laminas\Router\RouteInterface
      *
      * @see    \Laminas\Router\RouteInterface::match()
-     * @param  Request      $request
+     *
      * @param  integer|null $pathOffset
      * @param  array        $options
      * @return RouteMatch|null
@@ -291,7 +296,7 @@ class TreeRouteStack extends SimpleRouteStack
     public function match(Request $request, $pathOffset = null, array $options = [])
     {
         if (! method_exists($request, 'getUri')) {
-            return;
+            return null;
         }
 
         if ($this->baseUrl === null && method_exists($request, 'getBaseUrl')) {
@@ -316,7 +321,8 @@ class TreeRouteStack extends SimpleRouteStack
         }
 
         foreach ($this->routes as $name => $route) {
-            if (($match = $route->match($request, $baseUrlLength, $options)) instanceof RouteMatch
+            if (
+                ($match = $route->match($request, $baseUrlLength, $options)) instanceof RouteMatch
                 && ($pathLength === null || $match->getLength() === $pathLength)
             ) {
                 $match->setMatchedRouteName($name);
@@ -331,13 +337,14 @@ class TreeRouteStack extends SimpleRouteStack
             }
         }
 
-        return;
+        return null;
     }
 
     /**
      * assemble(): defined by \Laminas\Router\RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::assemble()
+     *
      * @param  array $params
      * @param  array $options
      * @return mixed
@@ -401,7 +408,8 @@ class TreeRouteStack extends SimpleRouteStack
             $uri->setFragment($options['fragment']);
         }
 
-        if ((isset($options['force_canonical'])
+        if (
+            (isset($options['force_canonical'])
             && $options['force_canonical'])
             || $uri->getHost() !== null
             || $uri->getScheme() !== null
@@ -463,7 +471,6 @@ class TreeRouteStack extends SimpleRouteStack
     /**
      * Set the request URI.
      *
-     * @param  HttpUri $uri
      * @return TreeRouteStack
      */
     public function setRequestUri(HttpUri $uri)

--- a/src/Http/Wildcard.php
+++ b/src/Http/Wildcard.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router\Http;
@@ -14,6 +8,21 @@ use Laminas\Router\Exception;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
 use Traversable;
+
+use function array_merge;
+use function array_shift;
+use function count;
+use function end;
+use function explode;
+use function implode;
+use function is_array;
+use function is_scalar;
+use function method_exists;
+use function rawurldecode;
+use function rawurlencode;
+use function sprintf;
+use function strlen;
+use function substr;
 
 /**
  * Wildcard route.
@@ -34,7 +43,7 @@ class Wildcard implements RouteInterface
     /**
      * Delimiter before parameters.
      *
-     * @var array
+     * @var string
      */
     protected $paramDelimiter;
 
@@ -70,6 +79,7 @@ class Wildcard implements RouteInterface
      * factory(): defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::factory()
+     *
      * @param  array|Traversable $options
      * @return Wildcard
      * @throws Exception\InvalidArgumentException
@@ -104,14 +114,14 @@ class Wildcard implements RouteInterface
      * match(): defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::match()
-     * @param  Request      $request
+     *
      * @param  integer|null $pathOffset
      * @return RouteMatch|null
      */
     public function match(Request $request, $pathOffset = null)
     {
         if (! method_exists($request, 'getUri')) {
-            return;
+            return null;
         }
 
         $uri  = $request->getUri();
@@ -129,7 +139,7 @@ class Wildcard implements RouteInterface
         $params  = explode($this->paramDelimiter, $path);
 
         if (count($params) > 1 && ($params[0] !== '' || end($params) === '')) {
-            return;
+            return null;
         }
 
         if ($this->keyValueDelimiter === $this->paramDelimiter) {
@@ -159,6 +169,7 @@ class Wildcard implements RouteInterface
      * assemble(): Defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::assemble()
+     *
      * @param  array $params
      * @param  array $options
      * @return mixed
@@ -175,7 +186,9 @@ class Wildcard implements RouteInterface
                     continue;
                 }
 
-                $elements[] = rawurlencode($key) . $this->keyValueDelimiter . rawurlencode((string) $value);
+                $elements[]              = rawurlencode($key)
+                    . $this->keyValueDelimiter
+                    . rawurlencode((string) $value);
                 $this->assembledParams[] = $key;
             }
 
@@ -189,6 +202,7 @@ class Wildcard implements RouteInterface
      * getAssembledParams(): defined by RouteInterface interface.
      *
      * @see    RouteInterface::getAssembledParams
+     *
      * @return array
      */
     public function getAssembledParams()

--- a/src/Module.php
+++ b/src/Module.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router;
@@ -25,8 +19,8 @@ class Module
         $provider = new ConfigProvider();
         return [
             'service_manager' => $provider->getDependencyConfig(),
-            'route_manager' => $provider->getRouteManagerConfig(),
-            'router' => ['routes' => []],
+            'route_manager'   => $provider->getRouteManagerConfig(),
+            'router'          => ['routes' => []],
         ];
     }
 }

--- a/src/PriorityList.php
+++ b/src/PriorityList.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router;

--- a/src/RouteInterface.php
+++ b/src/RouteInterface.php
@@ -1,16 +1,11 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router;
 
 use Laminas\Stdlib\RequestInterface as Request;
+use Traversable;
 
 /**
  * RouteInterface interface.
@@ -27,7 +22,7 @@ interface RouteInterface
     /**
      * Create a new route with given options.
      *
-     * @param  array|\Traversable $options
+     * @param array|Traversable $options
      * @return RouteInterface
      */
     public static function factory($options = []);
@@ -35,7 +30,6 @@ interface RouteInterface
     /**
      * Match a given request.
      *
-     * @param  Request $request
      * @return RouteMatch|null
      */
     public function match(Request $request);

--- a/src/RouteInvokableFactory.php
+++ b/src/RouteInvokableFactory.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router;
@@ -15,6 +9,10 @@ use Laminas\ServiceManager\AbstractFactoryInterface;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+
+use function class_exists;
+use function is_subclass_of;
+use function sprintf;
 
 /**
  * Specialized invokable/abstract factory for use with RoutePluginManager.
@@ -38,7 +36,6 @@ class RouteInvokableFactory implements
      *
      * Only works for FQCN $routeName values, for classes that implement RouteInterface.
      *
-     * @param ContainerInterface $container
      * @param string $routeName
      * @return bool
      */
@@ -60,7 +57,6 @@ class RouteInvokableFactory implements
      *
      * Proxies to canCreate().
      *
-     * @param ServiceLocatorInterface $container
      * @param string $normalizedName
      * @param string $routeName
      * @return bool
@@ -79,19 +75,18 @@ class RouteInvokableFactory implements
      * Otherwise, it uses the class' `factory()` method with the provided
      * $options to produce an instance.
      *
-     * @param ContainerInterface $container
      * @param string $routeName
      * @param null|array $options
      * @return RouteInterface
      */
-    public function __invoke(ContainerInterface $container, $routeName, array $options = null)
+    public function __invoke(ContainerInterface $container, $routeName, ?array $options = null)
     {
         $options = $options ?: [];
 
         if (! class_exists($routeName)) {
             throw new ServiceNotCreatedException(sprintf(
                 '%s: failed retrieving invokable class "%s"; class does not exist',
-                __CLASS__,
+                self::class,
                 $routeName
             ));
         }
@@ -99,7 +94,7 @@ class RouteInvokableFactory implements
         if (! is_subclass_of($routeName, RouteInterface::class)) {
             throw new ServiceNotCreatedException(sprintf(
                 '%s: failed retrieving invokable class "%s"; class does not implement %s',
-                __CLASS__,
+                self::class,
                 $routeName,
                 RouteInterface::class
             ));
@@ -113,7 +108,6 @@ class RouteInvokableFactory implements
      *
      * Proxies to __invoke().
      *
-     * @param ServiceLocatorInterface $container
      * @param string $normalizedName
      * @param string $routeName
      * @return RouteInterface
@@ -128,7 +122,8 @@ class RouteInvokableFactory implements
      *
      * For use with laminas-servicemanager v2; proxies to __invoke().
      *
-     * @param ServiceLocatorInterface $container
+     * @param null|string $normalizedName Not used
+     * @param null|string $routeName
      * @return RouteInterface
      */
     public function createService(ServiceLocatorInterface $container, $normalizedName = null, $routeName = null)

--- a/src/RouteMatch.php
+++ b/src/RouteMatch.php
@@ -1,14 +1,10 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router;
+
+use function array_key_exists;
 
 /**
  * RouteInterface match.

--- a/src/RoutePluginManager.php
+++ b/src/RoutePluginManager.php
@@ -1,18 +1,19 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router;
 
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\AbstractPluginManager;
+use Laminas\ServiceManager\ConfigInterface;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
+
+use function array_merge;
+use function get_class;
+use function gettype;
+use function is_object;
+use function sprintf;
 
 /**
  * Plugin manager implementation for routes
@@ -53,7 +54,7 @@ class RoutePluginManager extends AbstractPluginManager
      * Ensure that the instance is seeded with the RouteInvokableFactory as an
      * abstract factory.
      *
-     * @param ContainerInterface|\Laminas\ServiceManager\ConfigInterface $configOrContainerInstance
+     * @param ContainerInterface|ConfigInterface $configOrContainerInstance
      * @param array $v3config
      */
     public function __construct($configOrContainerInstance, array $v3config = [])
@@ -73,7 +74,7 @@ class RoutePluginManager extends AbstractPluginManager
         if (! $instance instanceof $this->instanceOf) {
             throw new InvalidServiceException(sprintf(
                 'Plugin of type %s is invalid; must implement %s',
-                (is_object($instance) ? get_class($instance) : gettype($instance)),
+                is_object($instance) ? get_class($instance) : gettype($instance),
                 RouteInterface::class
             ));
         }
@@ -131,15 +132,15 @@ class RoutePluginManager extends AbstractPluginManager
     }
 
      /**
-     * Create aliases for invokable classes.
-     *
-     * If an invokable service name does not match the class it maps to, this
-     * creates an alias to the class (which will later be mapped as an
-     * invokable factory).
-     *
-     * @param array $invokables
-     * @return array
-     */
+      * Create aliases for invokable classes.
+      *
+      * If an invokable service name does not match the class it maps to, this
+      * creates an alias to the class (which will later be mapped as an
+      * invokable factory).
+      *
+      * @param array $invokables
+      * @return array
+      */
     protected function createAliasesForInvokables(array $invokables)
     {
         $aliases = [];

--- a/src/RoutePluginManagerFactory.php
+++ b/src/RoutePluginManagerFactory.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router;
@@ -14,17 +8,17 @@ use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 
+/** @psalm-suppress DeprecatedInterface */
 class RoutePluginManagerFactory implements FactoryInterface
 {
     /**
      * Create and return a route plugin manager.
      *
-     * @param  ContainerInterface $container
      * @param  string $name
      * @param  null|array $options
      * @return RoutePluginManager
      */
-    public function __invoke(ContainerInterface $container, $name, array $options = null)
+    public function __invoke(ContainerInterface $container, $name, ?array $options = null)
     {
         $options = $options ?: [];
         return new RoutePluginManager($container, $options);

--- a/src/RouteStackInterface.php
+++ b/src/RouteStackInterface.php
@@ -1,14 +1,10 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router;
+
+use Traversable;
 
 interface RouteStackInterface extends RouteInterface
 {
@@ -25,7 +21,7 @@ interface RouteStackInterface extends RouteInterface
     /**
      * Add multiple routes to the stack.
      *
-     * @param  array|\Traversable $routes
+     * @param array|Traversable $routes
      * @return RouteStackInterface
      */
     public function addRoutes($routes);
@@ -41,7 +37,7 @@ interface RouteStackInterface extends RouteInterface
     /**
      * Remove all routes from the stack and set new ones.
      *
-     * @param  array|\Traversable $routes
+     * @param array|Traversable $routes
      * @return RouteStackInterface
      */
     public function setRoutes($routes);

--- a/src/RouterConfigTrait.php
+++ b/src/RouterConfigTrait.php
@@ -1,16 +1,13 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router;
 
 use Interop\Container\ContainerInterface;
+
+use function class_exists;
+use function sprintf;
 
 trait RouterConfigTrait
 {
@@ -19,7 +16,7 @@ trait RouterConfigTrait
      *
      * @param string $class
      * @param array $config
-     * @param ContainerInterface $container
+     * @return RouteInterface
      */
     private function createRouter($class, array $config, ContainerInterface $container)
     {
@@ -30,12 +27,12 @@ trait RouterConfigTrait
 
         // Inject the route plugins
         if (! isset($config['route_plugins'])) {
-            $routePluginManager = $container->get('RoutePluginManager');
+            $routePluginManager      = $container->get('RoutePluginManager');
             $config['route_plugins'] = $routePluginManager;
         }
 
         // Obtain an instance
         $factory = sprintf('%s::factory', $class);
-        return call_user_func($factory, $config);
+        return $factory($config);
     }
 }

--- a/src/RouterFactory.php
+++ b/src/RouterFactory.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router;
@@ -14,6 +8,7 @@ use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 
+/** @psalm-suppress DeprecatedInterface */
 class RouterFactory implements FactoryInterface
 {
     /**
@@ -21,12 +16,11 @@ class RouterFactory implements FactoryInterface
      *
      * Delegates to the HttpRouter service.
      *
-     * @param  ContainerInterface $container
      * @param  string $name
      * @param  null|array $options
      * @return RouteStackInterface
      */
-    public function __invoke(ContainerInterface $container, $name, array $options = null)
+    public function __invoke(ContainerInterface $container, $name, ?array $options = null)
     {
         return $container->get('HttpRouter');
     }
@@ -36,7 +30,6 @@ class RouterFactory implements FactoryInterface
      *
      * For use with laminas-servicemanager v2; proxies to __invoke().
      *
-     * @param ServiceLocatorInterface $container
      * @param null|string $normalizedName
      * @param null|string $requestedName
      * @return RouteStackInterface

--- a/src/SimpleRouteStack.php
+++ b/src/SimpleRouteStack.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace Laminas\Router;
@@ -14,6 +8,10 @@ use Laminas\ServiceManager\ServiceManager;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
 use Traversable;
+
+use function array_merge;
+use function is_array;
+use function sprintf;
 
 /**
  * Simple route stack implementation.
@@ -43,10 +41,8 @@ class SimpleRouteStack implements RouteStackInterface
 
     /**
      * Create a new simple route stack.
-     *
-     * @param RoutePluginManager $routePluginManager
      */
-    public function __construct(RoutePluginManager $routePluginManager = null)
+    public function __construct(?RoutePluginManager $routePluginManager = null)
     {
         $this->routes = new PriorityList();
 
@@ -63,6 +59,7 @@ class SimpleRouteStack implements RouteStackInterface
      * factory(): defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::factory()
+     *
      * @param  array|Traversable $options
      * @return SimpleRouteStack
      * @throws Exception\InvalidArgumentException
@@ -108,7 +105,6 @@ class SimpleRouteStack implements RouteStackInterface
     /**
      * Set the route plugin manager.
      *
-     * @param  RoutePluginManager $routePlugins
      * @return SimpleRouteStack
      */
     public function setRoutePluginManager(RoutePluginManager $routePlugins)
@@ -131,6 +127,7 @@ class SimpleRouteStack implements RouteStackInterface
      * addRoutes(): defined by RouteStackInterface interface.
      *
      * @see    RouteStackInterface::addRoutes()
+     *
      * @param  array|Traversable $routes
      * @return SimpleRouteStack
      * @throws Exception\InvalidArgumentException
@@ -152,6 +149,7 @@ class SimpleRouteStack implements RouteStackInterface
      * addRoute(): defined by RouteStackInterface interface.
      *
      * @see    RouteStackInterface::addRoute()
+     *
      * @param  string  $name
      * @param  mixed   $route
      * @param  int $priority
@@ -176,6 +174,7 @@ class SimpleRouteStack implements RouteStackInterface
      * removeRoute(): defined by RouteStackInterface interface.
      *
      * @see    RouteStackInterface::removeRoute()
+     *
      * @param  string $name
      * @return SimpleRouteStack
      */
@@ -293,7 +292,7 @@ class SimpleRouteStack implements RouteStackInterface
      * match(): defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::match()
-     * @param  Request $request
+     *
      * @return RouteMatch|null
      */
     public function match(Request $request)
@@ -312,13 +311,14 @@ class SimpleRouteStack implements RouteStackInterface
             }
         }
 
-        return;
+        return null;
     }
 
     /**
      * assemble(): defined by RouteInterface interface.
      *
      * @see    \Laminas\Router\RouteInterface::assemble()
+     *
      * @param  array $params
      * @param  array $options
      * @return mixed

--- a/test/FactoryTester.php
+++ b/test/FactoryTester.php
@@ -1,17 +1,14 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace LaminasTest\Router;
 
 use ArrayIterator;
+use Laminas\Router\Exception\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+
+use function sprintf;
 
 /**
  * Helper to test route factories.
@@ -27,8 +24,6 @@ class FactoryTester
 
     /**
      * Create a new factory tester.
-     *
-     * @param  TestCase $testCase
      */
     public function __construct(TestCase $testCase)
     {
@@ -38,16 +33,18 @@ class FactoryTester
     /**
      * Test a factory.
      *
-     * @param  string $className
+     * @param  string $classname
      * @return void
      */
     public function testFactory($classname, array $requiredOptions, array $options)
     {
+        $factory = sprintf('%s::factory', $classname);
+
         // Test that the factory does not allow a scalar option.
         try {
-            $classname::factory(0);
+            $factory(0);
             $this->testCase->fail('An expected exception was not thrown');
-        } catch (\Laminas\Router\Exception\InvalidArgumentException $e) {
+        } catch (InvalidArgumentException $e) {
             $this->testCase->assertStringContainsString(
                 'factory expects an array or Traversable set of options',
                 $e->getMessage()
@@ -61,17 +58,17 @@ class FactoryTester
             unset($testOptions[$option]);
 
             try {
-                $classname::factory($testOptions);
+                $factory($testOptions);
                 $this->testCase->fail('An expected exception was not thrown');
-            } catch (\Laminas\Router\Exception\InvalidArgumentException $e) {
+            } catch (InvalidArgumentException $e) {
                 $this->testCase->assertStringContainsString($exceptionMessage, $e->getMessage());
             }
         }
 
         // Create the route, will throw an exception if something goes wrong.
-        $classname::factory($options);
+        $factory($options);
 
         // Try the same with an iterator.
-        $classname::factory(new ArrayIterator($options));
+        $factory(new ArrayIterator($options));
     }
 }

--- a/test/Http/ChainTest.php
+++ b/test/Http/ChainTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace LaminasTest\Router\Http;
@@ -20,9 +14,12 @@ use Laminas\ServiceManager\ServiceManager;
 use LaminasTest\Router\FactoryTester;
 use PHPUnit\Framework\TestCase;
 
+use function strlen;
+use function strpos;
+
 class ChainTest extends TestCase
 {
-    public static function getRoute()
+    public static function getRoute(): Chain
     {
         $routePlugins = new RoutePluginManager(new ServiceManager());
 
@@ -54,7 +51,7 @@ class ChainTest extends TestCase
         );
     }
 
-    public static function getRouteWithOptionalParam()
+    public static function getRouteWithOptionalParam(): Chain
     {
         $routePlugins = new RoutePluginManager(new ServiceManager());
 
@@ -83,10 +80,18 @@ class ChainTest extends TestCase
         );
     }
 
-    public static function routeProvider()
+    /**
+     * @psalm-return array<string, array{
+     *     0: Chain,
+     *     1: string,
+     *     2: null|int,
+     *     3: array<string, string>
+     * }>
+     */
+    public static function routeProvider(): array
     {
         return [
-            'simple-match' => [
+            'simple-match'                  => [
                 self::getRoute(),
                 '/foo/bar',
                 null,
@@ -95,7 +100,7 @@ class ChainTest extends TestCase
                     'bar'        => 'bar',
                 ],
             ],
-            'offset-skips-beginning' => [
+            'offset-skips-beginning'        => [
                 self::getRoute(),
                 '/baz/foo/bar',
                 4,
@@ -110,25 +115,25 @@ class ChainTest extends TestCase
                 null,
                 [
                     'controller' => 'foo',
-                    'bar' => 'baz',
+                    'bar'        => 'baz',
                 ],
             ],
-            'optional-parameter' => [
+            'optional-parameter'            => [
                 self::getRouteWithOptionalParam(),
                 '/foo/baz',
                 null,
                 [
                     'controller' => 'foo',
-                    'bar' => 'baz',
+                    'bar'        => 'baz',
                 ],
             ],
-            'optional-parameter-empty' => [
+            'optional-parameter-empty'      => [
                 self::getRouteWithOptionalParam(),
                 '/foo',
                 null,
                 [
                     'controller' => 'foo',
-                    'bar' => 'bar',
+                    'bar'        => 'bar',
                 ],
             ],
         ];
@@ -136,12 +141,10 @@ class ChainTest extends TestCase
 
     /**
      * @dataProvider routeProvider
-     * @param        Chain   $route
-     * @param        string  $path
-     * @param        int     $offset
-     * @param        array   $params
+     * @param        string   $path
+     * @param        int|null $offset
      */
-    public function testMatching(Chain $route, $path, $offset, array $params = null)
+    public function testMatching(Chain $route, $path, $offset, ?array $params = null)
     {
         $request = new Request();
         $request->setUri('http://example.com' . $path);
@@ -164,12 +167,10 @@ class ChainTest extends TestCase
 
     /**
      * @dataProvider routeProvider
-     * @param        Chain   $route
-     * @param        string  $path
-     * @param        int     $offset
-     * @param        array   $params
+     * @param        string   $path
+     * @param        int|null $offset
      */
-    public function testAssembling(Chain $route, $path, $offset, array $params = null)
+    public function testAssembling(Chain $route, $path, $offset, ?array $params = null)
     {
         if ($params === null) {
             // Data which will not match are not tested for assembling.

--- a/test/Http/HostnameTest.php
+++ b/test/Http/HostnameTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace LaminasTest\Router\Http;
@@ -22,94 +16,101 @@ use PHPUnit\Framework\TestCase;
 
 class HostnameTest extends TestCase
 {
-    public static function routeProvider()
+    /**
+     * @psalm-return array<string, array{
+     *     0: Hostname,
+     *     1: string,
+     *     2: null|array<string, null|string>
+     * }>
+     */
+    public static function routeProvider(): array
     {
         return [
-            'simple-match' => [
+            'simple-match'                                                   => [
                 new Hostname(':foo.example.com'),
                 'bar.example.com',
-                ['foo' => 'bar']
+                ['foo' => 'bar'],
             ],
-            'no-match-on-different-hostname' => [
+            'no-match-on-different-hostname'                                 => [
                 new Hostname('foo.example.com'),
                 'bar.example.com',
-                null
+                null,
             ],
-            'no-match-with-different-number-of-parts' => [
+            'no-match-with-different-number-of-parts'                        => [
                 new Hostname('foo.example.com'),
                 'example.com',
-                null
+                null,
             ],
-            'no-match-with-different-number-of-parts-2' => [
+            'no-match-with-different-number-of-parts-2'                      => [
                 new Hostname('example.com'),
                 'foo.example.com',
-                null
+                null,
             ],
-            'match-overrides-default' => [
+            'match-overrides-default'                                        => [
                 new Hostname(':foo.example.com', [], ['foo' => 'baz']),
                 'bat.example.com',
-                ['foo' => 'bat']
+                ['foo' => 'bat'],
             ],
-            'constraints-prevent-match' => [
+            'constraints-prevent-match'                                      => [
                 new Hostname(':foo.example.com', ['foo' => '\d+']),
                 'bar.example.com',
-                null
+                null,
             ],
-            'constraints-allow-match' => [
+            'constraints-allow-match'                                        => [
                 new Hostname(':foo.example.com', ['foo' => '\d+']),
                 '123.example.com',
-                ['foo' => '123']
+                ['foo' => '123'],
             ],
-            'constraints-allow-match-2' => [
+            'constraints-allow-match-2'                                      => [
                 new Hostname(
                     'www.:domain.com',
                     ['domain' => '(mydomain|myaltdomain1|myaltdomain2)'],
-                    ['domain'    => 'mydomain']
+                    ['domain' => 'mydomain']
                 ),
                 'www.mydomain.com',
-                ['domain' => 'mydomain']
+                ['domain' => 'mydomain'],
             ],
-            'optional-subdomain' => [
+            'optional-subdomain'                                             => [
                 new Hostname('[:foo.]example.com'),
                 'bar.example.com',
                 ['foo' => 'bar'],
             ],
-            'two-optional-subdomain' => [
+            'two-optional-subdomain'                                         => [
                 new Hostname('[:foo.][:bar.]example.com'),
                 'baz.bat.example.com',
                 ['foo' => 'baz', 'bar' => 'bat'],
             ],
-            'missing-optional-subdomain' => [
+            'missing-optional-subdomain'                                     => [
                 new Hostname('[:foo.]example.com'),
                 'example.com',
                 ['foo' => null],
             ],
-            'one-of-two-missing-optional-subdomain' => [
+            'one-of-two-missing-optional-subdomain'                          => [
                 new Hostname('[:foo.][:bar.]example.com'),
                 'bat.example.com',
                 ['foo' => null, 'foo' => 'bat'],
             ],
-            'two-missing-optional-subdomain' => [
+            'two-missing-optional-subdomain'                                 => [
                 new Hostname('[:foo.][:bar.]example.com'),
                 'example.com',
                 ['foo' => null, 'bar' => null],
             ],
-            'two-optional-subdomain-nested' => [
+            'two-optional-subdomain-nested'                                  => [
                 new Hostname('[[:foo.]:bar.]example.com'),
                 'baz.bat.example.com',
                 ['foo' => 'baz', 'bar' => 'bat'],
             ],
-            'one-of-two-missing-optional-subdomain-nested' => [
+            'one-of-two-missing-optional-subdomain-nested'                   => [
                 new Hostname('[[:foo.]:bar.]example.com'),
                 'bat.example.com',
                 ['foo' => null, 'bar' => 'bat'],
             ],
-            'two-missing-optional-subdomain-nested' => [
+            'two-missing-optional-subdomain-nested'                          => [
                 new Hostname('[[:foo.]:bar.]example.com'),
                 'example.com',
                 ['foo' => null, 'bar' => null],
             ],
-            'no-match-on-different-hostname-and-optional-subdomain' => [
+            'no-match-on-different-hostname-and-optional-subdomain'          => [
                 new Hostname('[:foo.]example.com'),
                 'bar.test.com',
                 null,
@@ -119,42 +120,42 @@ class HostnameTest extends TestCase
                 'bar.baz.example.com',
                 null,
             ],
-            'match-overrides-default-optional-subdomain' => [
+            'match-overrides-default-optional-subdomain'                     => [
                 new Hostname('[:foo.]:bar.example.com', [], ['bar' => 'baz']),
                 'bat.qux.example.com',
                 ['foo' => 'bat', 'bar' => 'qux'],
             ],
-            'constraints-prevent-match-optional-subdomain' => [
+            'constraints-prevent-match-optional-subdomain'                   => [
                 new Hostname('[:foo.]example.com', ['foo' => '\d+']),
                 'bar.example.com',
                 null,
             ],
-            'constraints-allow-match-optional-subdomain' => [
+            'constraints-allow-match-optional-subdomain'                     => [
                 new Hostname('[:foo.]example.com', ['foo' => '\d+']),
                 '123.example.com',
                 ['foo' => '123'],
             ],
-            'middle-subdomain-optional' => [
+            'middle-subdomain-optional'                                      => [
                 new Hostname(':foo.[:bar.]example.com'),
                 'baz.bat.example.com',
                 ['foo' => 'baz', 'bar' => 'bat'],
             ],
-            'missing-middle-subdomain-optional' => [
+            'missing-middle-subdomain-optional'                              => [
                 new Hostname(':foo.[:bar.]example.com'),
                 'baz.example.com',
                 ['foo' => 'baz'],
             ],
-            'non-standard-delimeter' => [
+            'non-standard-delimeter'                                         => [
                 new Hostname('user-:username.example.com'),
                 'user-jdoe.example.com',
                 ['username' => 'jdoe'],
             ],
-            'non-standard-delimeter-optional' => [
+            'non-standard-delimeter-optional'                                => [
                 new Hostname(':page{-}[-:username].example.com'),
                 'article-jdoe.example.com',
                 ['page' => 'article', 'username' => 'jdoe'],
             ],
-            'missing-non-standard-delimeter-optional' => [
+            'missing-non-standard-delimeter-optional'                        => [
                 new Hostname(':page{-}[-:username].example.com'),
                 'article.example.com',
                 ['page' => 'article'],
@@ -164,11 +165,10 @@ class HostnameTest extends TestCase
 
     /**
      * @dataProvider routeProvider
-     * @param        Hostname $route
      * @param        string   $hostname
      * @param        array    $params
      */
-    public function testMatching(Hostname $route, $hostname, array $params = null)
+    public function testMatching(Hostname $route, $hostname, ?array $params = null)
     {
         $request = new Request();
         $request->setUri('http://' . $hostname . '/');
@@ -187,11 +187,10 @@ class HostnameTest extends TestCase
 
     /**
      * @dataProvider routeProvider
-     * @param        Hostname $route
      * @param        string   $hostname
      * @param        array    $params
      */
-    public function testAssembling(Hostname $route, $hostname, array $params = null)
+    public function testAssembling(Hostname $route, $hostname, ?array $params = null)
     {
         if ($params === null) {
             // Data which will not match are not tested for assembling.
@@ -268,10 +267,10 @@ class HostnameTest extends TestCase
         $tester->testFactory(
             Hostname::class,
             [
-                'route' => 'Missing "route" in options array'
+                'route' => 'Missing "route" in options array',
             ],
             [
-                'route' => 'example.com'
+                'route' => 'example.com',
             ]
         );
     }

--- a/test/Http/HttpRouterFactoryTest.php
+++ b/test/Http/HttpRouterFactoryTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace LaminasTest\Router\Http;
@@ -26,6 +20,6 @@ class HttpRouterFactoryTest extends TestCase
             ],
         ];
 
-        $this->factory  = new HttpRouterFactory();
+        $this->factory = new HttpRouterFactory();
     }
 }

--- a/test/Http/LiteralTest.php
+++ b/test/Http/LiteralTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace LaminasTest\Router\Http;
@@ -17,50 +11,60 @@ use Laminas\Stdlib\Request as BaseRequest;
 use LaminasTest\Router\FactoryTester;
 use PHPUnit\Framework\TestCase;
 
+use function strlen;
+use function strpos;
+
 class LiteralTest extends TestCase
 {
-    public static function routeProvider()
+    /**
+     * @psalm-return array<string, array{
+     *     0: Literal,
+     *     1: string,
+     *     2: null|int,
+     *     3: bool
+     * }>
+     */
+    public static function routeProvider(): array
     {
         return [
-            'simple-match' => [
+            'simple-match'                    => [
                 new Literal('/foo'),
                 '/foo',
                 null,
-                true
+                true,
             ],
-            'no-match-without-leading-slash' => [
+            'no-match-without-leading-slash'  => [
                 new Literal('foo'),
                 '/foo',
                 null,
-                false
+                false,
             ],
-            'no-match-with-trailing-slash' => [
+            'no-match-with-trailing-slash'    => [
                 new Literal('/foo'),
                 '/foo/',
                 null,
-                false
+                false,
             ],
-            'offset-skips-beginning' => [
+            'offset-skips-beginning'          => [
                 new Literal('foo'),
                 '/foo',
                 1,
-                true
+                true,
             ],
             'offset-enables-partial-matching' => [
                 new Literal('/foo'),
                 '/foo/bar',
                 0,
-                true
+                true,
             ],
         ];
     }
 
     /**
      * @dataProvider routeProvider
-     * @param        Literal $route
-     * @param        string  $path
-     * @param        int     $offset
-     * @param        bool    $shouldMatch
+     * @param        string   $path
+     * @param        int|null $offset
+     * @param        bool     $shouldMatch
      */
     public function testMatching(Literal $route, $path, $offset, $shouldMatch)
     {
@@ -81,10 +85,9 @@ class LiteralTest extends TestCase
 
     /**
      * @dataProvider routeProvider
-     * @param        Literal $route
-     * @param        string  $path
-     * @param        int     $offset
-     * @param        bool    $shouldMatch
+     * @param        string   $path
+     * @param        int|null $offset
+     * @param        bool     $shouldMatch
      */
     public function testAssembling(Literal $route, $path, $offset, $shouldMatch)
     {
@@ -125,10 +128,10 @@ class LiteralTest extends TestCase
         $tester->testFactory(
             Literal::class,
             [
-                'route' => 'Missing "route" in options array'
+                'route' => 'Missing "route" in options array',
             ],
             [
-                'route' => '/foo'
+                'route' => '/foo',
             ]
         );
     }
@@ -139,7 +142,7 @@ class LiteralTest extends TestCase
     public function testEmptyLiteral()
     {
         $request = new Request();
-        $route = new Literal('');
+        $route   = new Literal('');
         $this->assertNull($route->match($request, 0));
     }
 }

--- a/test/Http/MethodTest.php
+++ b/test/Http/MethodTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace LaminasTest\Router\Http;
@@ -19,35 +13,37 @@ use PHPUnit\Framework\TestCase;
 
 class MethodTest extends TestCase
 {
-    public static function routeProvider()
+    /**
+     * @psalm-return array<string, array{
+     *     0: HttpMethod,
+     *     1: string
+     * }>
+     */
+    public static function routeProvider(): array
     {
         return [
-            'simple-match' => [
+            'simple-match'                   => [
                 new HttpMethod('get'),
-                'get'
+                'get',
             ],
-            'match-comma-separated-verbs' => [
+            'match-comma-separated-verbs'    => [
                 new HttpMethod('get,post'),
-                'get'
+                'get',
             ],
             'match-comma-separated-verbs-ws' => [
                 new HttpMethod('get ,   post , put'),
-                'post'
+                'post',
             ],
-            'match-ignores-case' => [
+            'match-ignores-case'             => [
                 new HttpMethod('Get'),
-                'get'
-            ]
+                'get',
+            ],
         ];
     }
 
     /**
      * @dataProvider routeProvider
-     * @param    HttpMethod $route
-     * @param    $verb
-     * @internal param string $path
-     * @internal param int $offset
-     * @internal param bool $shouldMatch
+     * @param string $verb
      */
     public function testMatching(HttpMethod $route, $verb)
     {
@@ -73,10 +69,10 @@ class MethodTest extends TestCase
         $tester->testFactory(
             HttpMethod::class,
             [
-                'verb' => 'Missing "verb" in options array'
+                'verb' => 'Missing "verb" in options array',
             ],
             [
-                'verb' => 'get'
+                'verb' => 'get',
             ]
         );
     }

--- a/test/Http/PartTest.php
+++ b/test/Http/PartTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace LaminasTest\Router\Http;
@@ -27,12 +21,15 @@ use Laminas\Stdlib\Request as BaseRequest;
 use LaminasTest\Router\FactoryTester;
 use PHPUnit\Framework\TestCase;
 
+use function strlen;
+use function strpos;
+
 class PartTest extends TestCase
 {
-    public static function getRoutePlugins()
+    public static function getRoutePlugins(): RoutePluginManager
     {
         return new RoutePluginManager(new ServiceManager(), [
-            'aliases' => [
+            'aliases'   => [
                 'literal'  => Literal::class,
                 'Literal'  => Literal::class,
                 'part'     => Part::class,
@@ -51,7 +48,6 @@ class PartTest extends TestCase
                 Wildcard::class => RouteInvokableFactory::class,
 
                 // v2 normalized names
-
                 'laminasmvcrouterhttpliteral'  => RouteInvokableFactory::class,
                 'laminasmvcrouterhttppart'     => RouteInvokableFactory::class,
                 'laminasmvcrouterhttpsegment'  => RouteInvokableFactory::class,
@@ -60,7 +56,7 @@ class PartTest extends TestCase
         ]);
     }
 
-    public static function getRoute()
+    public static function getRoute(): Part
     {
         return new Part(
             [
@@ -68,9 +64,9 @@ class PartTest extends TestCase
                 'options' => [
                     'route'    => '/foo',
                     'defaults' => [
-                        'controller' => 'foo'
-                    ]
-                ]
+                        'controller' => 'foo',
+                    ],
+                ],
             ],
             true,
             self::getRoutePlugins(),
@@ -80,185 +76,194 @@ class PartTest extends TestCase
                     'options' => [
                         'route'    => '/bar',
                         'defaults' => [
-                            'controller' => 'bar'
-                        ]
-                    ]
+                            'controller' => 'bar',
+                        ],
+                    ],
                 ],
                 'baz' => [
-                    'type'    => Literal::class,
-                    'options' => [
-                        'route' => '/baz'
+                    'type'         => Literal::class,
+                    'options'      => [
+                        'route' => '/baz',
                     ],
                     'child_routes' => [
                         'bat' => [
-                            'type'    => Segment::class,
-                            'options' => [
-                                'route' => '/:controller'
+                            'type'          => Segment::class,
+                            'options'       => [
+                                'route' => '/:controller',
                             ],
                             'may_terminate' => true,
                             'child_routes'  => [
                                 'wildcard' => [
-                                    'type' => Wildcard::class
-                                ]
-                            ]
-                        ]
-                    ]
+                                    'type' => Wildcard::class,
+                                ],
+                            ],
+                        ],
+                    ],
                 ],
                 'bat' => [
-                    'type'    => Segment::class,
-                    'options' => [
+                    'type'          => Segment::class,
+                    'options'       => [
                         'route'    => '/bat[/:foo]',
                         'defaults' => [
-                            'foo' => 'bar'
-                        ]
+                            'foo' => 'bar',
+                        ],
                     ],
                     'may_terminate' => true,
                     'child_routes'  => [
-                        'literal' => [
-                            'type'   => Literal::class,
+                        'literal'  => [
+                            'type'    => Literal::class,
                             'options' => [
-                                'route' => '/bar'
-                            ]
+                                'route' => '/bar',
+                            ],
                         ],
                         'optional' => [
-                            'type'   => Segment::class,
+                            'type'    => Segment::class,
                             'options' => [
-                                'route' => '/bat[/:bar]'
-                            ]
+                                'route' => '/bat[/:bar]',
+                            ],
                         ],
-                    ]
-                ]
+                    ],
+                ],
             ]
         );
     }
 
-    public static function getRouteAlternative()
+    public static function getRouteAlternative(): Part
     {
         return new Part(
             [
-                'type' => Segment::class,
+                'type'    => Segment::class,
                 'options' => [
-                    'route' => '/[:controller[/:action]]',
+                    'route'    => '/[:controller[/:action]]',
                     'defaults' => [
                         'controller' => 'fo-fo',
-                        'action' => 'index'
-                    ]
-                ]
+                        'action'     => 'index',
+                    ],
+                ],
             ],
             true,
             self::getRoutePlugins(),
             [
                 'wildcard' => [
-                    'type' => Wildcard::class,
+                    'type'    => Wildcard::class,
                     'options' => [
                         'key_value_delimiter' => '/',
-                        'param_delimiter' => '/'
-                    ]
+                        'param_delimiter'     => '/',
+                    ],
                 ],
             ]
         );
     }
 
-    public static function routeProvider()
+    /**
+     * @psalm-return array<string, array{
+     *     0: Part,
+     *     1: string,
+     *     2: null|int,
+     *     3: null|string,
+     *     4: null|array<string, string>
+     * }>
+     */
+    public static function routeProvider(): array
     {
         return [
-            'simple-match' => [
+            'simple-match'                                     => [
                 self::getRoute(),
                 '/foo',
                 null,
                 null,
-                ['controller' => 'foo']
+                ['controller' => 'foo'],
             ],
-            'offset-skips-beginning' => [
+            'offset-skips-beginning'                           => [
                 self::getRoute(),
                 '/bar/foo',
                 4,
                 null,
-                ['controller' => 'foo']
+                ['controller' => 'foo'],
             ],
-            'simple-child-match' => [
+            'simple-child-match'                               => [
                 self::getRoute(),
                 '/foo/bar',
                 null,
                 'bar',
-                ['controller' => 'bar']
+                ['controller' => 'bar'],
             ],
-            'offset-does-not-enable-partial-matching' => [
+            'offset-does-not-enable-partial-matching'          => [
                 self::getRoute(),
                 '/foo/foo',
                 null,
                 null,
-                null
+                null,
             ],
             'offset-does-not-enable-partial-matching-in-child' => [
                 self::getRoute(),
                 '/foo/bar/baz',
                 null,
                 null,
-                null
+                null,
             ],
-            'non-terminating-part-does-not-match' => [
+            'non-terminating-part-does-not-match'              => [
                 self::getRoute(),
                 '/foo/baz',
                 null,
                 null,
-                null
+                null,
             ],
-            'child-of-non-terminating-part-does-match' => [
+            'child-of-non-terminating-part-does-match'         => [
                 self::getRoute(),
                 '/foo/baz/bat',
                 null,
                 'baz/bat',
-                ['controller' => 'bat']
+                ['controller' => 'bat'],
             ],
-            'parameters-are-used-only-once' => [
+            'parameters-are-used-only-once'                    => [
                 self::getRoute(),
                 '/foo/baz/wildcard/foo/bar',
                 null,
                 'baz/bat/wildcard',
-                ['controller' => 'wildcard', 'foo' => 'bar']
+                ['controller' => 'wildcard', 'foo' => 'bar'],
             ],
-            'optional-parameters-are-dropped-without-child' => [
+            'optional-parameters-are-dropped-without-child'    => [
                 self::getRoute(),
                 '/foo/bat',
                 null,
                 'bat',
-                ['foo' => 'bar']
+                ['foo' => 'bar'],
             ],
-            'optional-parameters-are-not-dropped-with-child' => [
+            'optional-parameters-are-not-dropped-with-child'   => [
                 self::getRoute(),
                 '/foo/bat/bar/bar',
                 null,
                 'bat/literal',
-                ['foo' => 'bar']
+                ['foo' => 'bar'],
             ],
-            'optional-parameters-not-required-in-last-part' => [
+            'optional-parameters-not-required-in-last-part'    => [
                 self::getRoute(),
                 '/foo/bat/bar/bat',
                 null,
                 'bat/optional',
-                ['foo' => 'bar']
+                ['foo' => 'bar'],
             ],
-            'simple-match' => [
+            'simple-match'                                     => [
                 self::getRouteAlternative(),
                 '/',
                 null,
                 null,
                 [
                     'controller' => 'fo-fo',
-                    'action' => 'index'
-                ]
+                    'action'     => 'index',
+                ],
             ],
-            'match-wildcard' => [
+            'match-wildcard'                                   => [
                 self::getRouteAlternative(),
                 '/fo-fo/index/param1/value1',
                 null,
                 'wildcard',
                 [
-                        'controller' => 'fo-fo',
-                        'action' => 'index',
-                        'param1' => 'value1'
-                ]
+                    'controller' => 'fo-fo',
+                    'action'     => 'index',
+                    'param1'     => 'value1',
+                ],
             ],
             /*
             'match-query' => array(
@@ -277,13 +282,11 @@ class PartTest extends TestCase
 
     /**
      * @dataProvider routeProvider
-     * @param        Part    $route
-     * @param        string  $path
-     * @param        int     $offset
-     * @param        string  $routeName
-     * @param        array   $params
+     * @param        string   $path
+     * @param        int|null $offset
+     * @param        string   $routeName
      */
-    public function testMatching(Part $route, $path, $offset, $routeName, array $params = null)
+    public function testMatching(Part $route, $path, $offset, $routeName, ?array $params = null)
     {
         $request = new Request();
         $request->setUri('http://example.com' . $path);
@@ -308,13 +311,11 @@ class PartTest extends TestCase
 
     /**
      * @dataProvider routeProvider
-     * @param        Part    $route
-     * @param        string  $path
-     * @param        int     $offset
-     * @param        string  $routeName
-     * @param        array   $params
+     * @param        string   $path
+     * @param        int|null $offset
+     * @param        string   $routeName
      */
-    public function testAssembling(Part $route, $path, $offset, $routeName, array $params = null)
+    public function testAssembling(Part $route, $path, $offset, $routeName, ?array $params = null)
     {
         if ($params === null) {
             // Data which will not match are not tested for assembling.
@@ -369,10 +370,10 @@ class PartTest extends TestCase
             Part::class,
             [
                 'route'         => 'Missing "route" in options array',
-                'route_plugins' => 'Missing "route_plugins" in options array'
+                'route_plugins' => 'Missing "route_plugins" in options array',
             ],
             [
-                'route'         => new \Laminas\Router\Http\Literal('/foo'),
+                'route'         => new Literal('/foo'),
                 'route_plugins' => self::getRoutePlugins(),
             ]
         );
@@ -387,7 +388,7 @@ class PartTest extends TestCase
             'create' => [
                 'type'    => 'Literal',
                 'options' => [
-                    'route' => 'create',
+                    'route'    => 'create',
                     'defaults' => [
                         'controller' => 'user-admin',
                         'action'     => 'edit',
@@ -395,11 +396,11 @@ class PartTest extends TestCase
                 ],
             ],
         ]);
-        $options = [
-            'route'        => [
-                'type' => Literal::class,
+        $options  = [
+            'route'         => [
+                'type'    => Literal::class,
                 'options' => [
-                    'route' => '/admin/users',
+                    'route'    => '/admin/users',
                     'defaults' => [
                         'controller' => 'Admin\UserController',
                         'action'     => 'index',
@@ -421,10 +422,10 @@ class PartTest extends TestCase
     public function testPartRouteMarkedAsMayTerminateCanMatchWhenQueryStringPresent()
     {
         $options = [
-            'route' => [
-                'type' => Literal::class,
+            'route'         => [
+                'type'    => Literal::class,
                 'options' => [
-                    'route' => '/resource',
+                    'route'    => '/resource',
                     'defaults' => [
                         'controller' => 'ResourceController',
                         'action'     => 'resource',
@@ -435,9 +436,9 @@ class PartTest extends TestCase
             'may_terminate' => true,
             'child_routes'  => [
                 'child' => [
-                    'type' => Literal::class,
+                    'type'    => Literal::class,
                     'options' => [
-                        'route' => '/child',
+                        'route'    => '/child',
                         'defaults' => [
                             'action' => 'child',
                         ],
@@ -446,7 +447,7 @@ class PartTest extends TestCase
             ],
         ];
 
-        $route = Part::factory($options);
+        $route   = Part::factory($options);
         $request = new Request();
         $request->setUri('http://example.com/resource?foo=bar');
         $query = new Parameters(['foo' => 'bar']);
@@ -464,10 +465,10 @@ class PartTest extends TestCase
     public function testPartRouteMarkedAsMayTerminateButWithQueryRouteChildWillMatchChildRoute()
     {
         $options = [
-            'route' => [
-                'type' => Literal::class,
+            'route'         => [
+                'type'    => Literal::class,
                 'options' => [
-                    'route' => '/resource',
+                    'route'    => '/resource',
                     'defaults' => [
                         'controller' => 'ResourceController',
                         'action'     => 'resource',
@@ -478,7 +479,7 @@ class PartTest extends TestCase
             'may_terminate' => true,
         ];
 
-        $route = Part::factory($options);
+        $route   = Part::factory($options);
         $request = new Request();
         $request->setUri('http://example.com/resource?foo=bar');
         $query = new Parameters(['foo' => 'bar']);

--- a/test/Http/PlaceholderTest.php
+++ b/test/Http/PlaceholderTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Router\Http;
 
 use Laminas\Http\Request;
@@ -20,27 +14,28 @@ use PHPUnit\Framework\TestCase;
 
 class PlaceholderTest extends TestCase
 {
+    /** @var array<string, array<string, mixed>> */
     private static $routeConfig = [
         'auth' => [
-            'type' => Placeholder::class,
+            'type'         => Placeholder::class,
             'child_routes' => [
-                'login' => [
-                    'type' => Literal::class,
+                'login'    => [
+                    'type'    => Literal::class,
                     'options' => [
-                        'route' => '/',
+                        'route'    => '/',
                         'defaults' => [
                             'controller' => 'AuthController',
-                            'action' => 'login'
+                            'action'     => 'login',
                         ],
                     ],
                 ],
                 'register' => [
-                    'type' => Literal::class,
+                    'type'    => Literal::class,
                     'options' => [
-                        'route' => '/register',
+                        'route'    => '/register',
                         'defaults' => [
                             'controller' => 'RegistrationController',
-                            'action' => 'register'
+                            'action'     => 'register',
                         ],
                     ],
                 ],
@@ -85,7 +80,7 @@ class PlaceholderTest extends TestCase
     public function testPlaceholderDefault($additionalConfig, $uri, $expectedRouteName)
     {
         $routeConfig = ArrayUtils::merge(self::$routeConfig, $additionalConfig);
-        $router = TreeRouteStack::factory(['routes' => $routeConfig]);
+        $router      = TreeRouteStack::factory(['routes' => $routeConfig]);
 
         $request = new Request();
         $request->setUri($uri);
@@ -95,56 +90,63 @@ class PlaceholderTest extends TestCase
         $this->assertEquals($expectedRouteName, $match->getMatchedRouteName());
     }
 
-    public function placeholderProvider()
+    /**
+     * @psalm-return array<string, array{
+     *     0: array<string, array<string, mixed>>,
+     *     1: string,
+     *     2: string
+     * }>
+     */
+    public function placeholderProvider(): array
     {
         $home = [
             'home' => [
-                'type' => Literal::class,
+                'type'    => Literal::class,
                 'options' => [
-                    'route' => '/home',
+                    'route'    => '/home',
                     'defaults' => [
                         'controller' => 'HomeController',
-                        'action' => 'index'
+                        'action'     => 'index',
                     ],
                 ],
-            ]
+            ],
         ];
 
         $homeAtRootAuthMoved = [
             'home' => [
-                'type' => Literal::class,
+                'type'    => Literal::class,
                 'options' => [
-                    'route' => '/',
+                    'route'    => '/',
                     'defaults' => [
                         'controller' => 'HomeController',
-                        'action' => 'index'
+                        'action'     => 'index',
                     ],
                 ],
             ],
             'auth' => [
-                'type' => Literal::class,
-                'options' => ['route' => '/auth']
-            ]
+                'type'    => Literal::class,
+                'options' => ['route' => '/auth'],
+            ],
         ];
 
         $homeAtRootAuthOnSubDomain = [
             'home' => [
-                'type' => Hostname::class,
+                'type'    => Hostname::class,
                 'options' => [
-                    'route' => 'example.com',
+                    'route'    => 'example.com',
                     'defaults' => [
                         'controller' => 'HomeController',
-                        'action' => 'index'
+                        'action'     => 'index',
                     ],
                 ],
             ],
             'auth' => [
-                'type' => Hostname::class,
-                'options' => ['route' => 'auth.example.com']
-            ]
+                'type'    => Hostname::class,
+                'options' => ['route' => 'auth.example.com'],
+            ],
         ];
 
-        // @codingStandardsIgnoreStart
+        // phpcs:disable Generic.Files.LineLength.TooLong
         return [
             'no-override-login'           => [$home,                      'http://example.com/',              'auth/login'],
             'no-override-register'        => [$home,                      'http://example.com/register',      'auth/register'],
@@ -156,6 +158,6 @@ class PlaceholderTest extends TestCase
             'subdomain-override-register' => [$homeAtRootAuthOnSubDomain, 'http://auth.example.com/register', 'auth/register'],
             'subdomina-override-home'     => [$homeAtRootAuthOnSubDomain, 'http://example.com/',              'home'],
         ];
-        // @codingStandardsIgnoreEnd
+        // phpcs:enable Generic.Files.LineLength.TooLong
     }
 }

--- a/test/Http/RouteMatchTest.php
+++ b/test/Http/RouteMatchTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace LaminasTest\Router\Http;

--- a/test/Http/SchemeTest.php
+++ b/test/Http/SchemeTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace LaminasTest\Router\Http;

--- a/test/Http/TestAsset/DummyRoute.php
+++ b/test/Http/TestAsset/DummyRoute.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace LaminasTest\Router\Http\TestAsset;
@@ -23,7 +17,7 @@ class DummyRoute implements RouteInterface
      * match(): defined by RouteInterface interface.
      *
      * @see    Route::match()
-     * @param  RequestInterface $request
+     *
      * @param  int $pathOffset
      * @return RouteMatch
      */
@@ -36,11 +30,12 @@ class DummyRoute implements RouteInterface
      * assemble(): defined by RouteInterface interface.
      *
      * @see    Route::assemble()
+     *
      * @param  array $params
      * @param  array $options
      * @return mixed
      */
-    public function assemble(array $params = null, array $options = null)
+    public function assemble(?array $params = null, ?array $options = null)
     {
         return '';
     }
@@ -60,6 +55,7 @@ class DummyRoute implements RouteInterface
      * getAssembledParams(): defined by RouteInterface interface.
      *
      * @see    Route::getAssembledParams
+     *
      * @return array
      */
     public function getAssembledParams()

--- a/test/Http/TestAsset/DummyRouteWithParam.php
+++ b/test/Http/TestAsset/DummyRouteWithParam.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace LaminasTest\Router\Http\TestAsset;
@@ -22,7 +16,7 @@ class DummyRouteWithParam extends DummyRoute
      * match(): defined by RouteInterface interface.
      *
      * @see    Route::match()
-     * @param  RequestInterface $request
+     *
      * @param  int $pathOffset
      * @return RouteMatch
      */
@@ -35,11 +29,12 @@ class DummyRouteWithParam extends DummyRoute
      * assemble(): defined by RouteInterface interface.
      *
      * @see    Route::assemble()
+     *
      * @param  array $params
      * @param  array $options
      * @return mixed
      */
-    public function assemble(array $params = null, array $options = null)
+    public function assemble(?array $params = null, ?array $options = null)
     {
         if (isset($params['foo'])) {
             return $params['foo'];

--- a/test/Http/TranslatorAwareTreeRouteStackTest.php
+++ b/test/Http/TranslatorAwareTreeRouteStackTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace LaminasTest\Router\Http;
@@ -20,19 +14,13 @@ use PHPUnit\Framework\TestCase;
 
 class TranslatorAwareTreeRouteStackTest extends TestCase
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $testFilesDir;
 
-    /**
-     * @var Translator
-     */
+    /** @var Translator */
     protected $translator;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $fooRoute;
 
     public function setUp(): void
@@ -46,13 +34,13 @@ class TranslatorAwareTreeRouteStackTest extends TestCase
         $this->translator->addTranslationFile('phpArray', $this->testFilesDir . '/tokens.de.php', 'route', 'de');
 
         $this->fooRoute = [
-            'type' => 'Segment',
-            'options' => [
+            'type'         => 'Segment',
+            'options'      => [
                 'route' => '/:locale',
             ],
             'child_routes' => [
                 'index' => [
-                    'type' => 'Segment',
+                    'type'    => 'Segment',
                     'options' => [
                         'route' => '/{homepage}',
                     ],

--- a/test/Http/TreeRouteStackTest.php
+++ b/test/Http/TreeRouteStackTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace LaminasTest\Router\Http;
@@ -20,7 +14,9 @@ use Laminas\Router\Http\TreeRouteStack;
 use Laminas\Stdlib\Request as BaseRequest;
 use Laminas\Uri\Http as HttpUri;
 use LaminasTest\Router\FactoryTester;
+use LaminasTest\Router\TestAsset\DummyRoute;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
 class TreeRouteStackTest extends TestCase
 {
@@ -30,7 +26,7 @@ class TreeRouteStackTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Route definition must be an array or Traversable object');
-        $stack->addRoute('foo', new \LaminasTest\Router\TestAsset\DummyRoute());
+        $stack->addRoute('foo', new DummyRoute());
     }
 
     public function testAddRouteViaStringRequiresHttpSpecificRoute()
@@ -40,7 +36,7 @@ class TreeRouteStackTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Given route does not implement HTTP route interface');
         $stack->addRoute('foo', [
-            'type' => \LaminasTest\Router\TestAsset\DummyRoute::class
+            'type' => DummyRoute::class,
         ]);
     }
 
@@ -48,14 +44,14 @@ class TreeRouteStackTest extends TestCase
     {
         $stack = new TreeRouteStack();
         $stack->addRoute('foo', new ArrayIterator([
-            'type' => TestAsset\DummyRoute::class
+            'type' => TestAsset\DummyRoute::class,
         ]));
         $this->assertTrue($stack->hasRoute('foo'));
     }
 
     public function testNoMatchWithoutUriMethod()
     {
-        $stack  = new TreeRouteStack();
+        $stack   = new TreeRouteStack();
         $request = new BaseRequest();
 
         $this->assertNull($stack->match($request));
@@ -81,7 +77,7 @@ class TreeRouteStackTest extends TestCase
         $stack = new TreeRouteStack();
         $stack->setBaseUrl('/foo');
         $stack->addRoute('foo', [
-            'type' => TestAsset\DummyRoute::class
+            'type' => TestAsset\DummyRoute::class,
         ]);
 
         $this->assertEquals(4, $stack->match(new Request())->getParam('offset'));
@@ -91,7 +87,7 @@ class TreeRouteStackTest extends TestCase
     {
         $stack = new TreeRouteStack();
         $stack->addRoute('foo', [
-            'type' => TestAsset\DummyRoute::class
+            'type' => TestAsset\DummyRoute::class,
         ]);
 
         $this->assertEquals(null, $stack->match(new Request())->getParam('offset'));
@@ -143,7 +139,7 @@ class TreeRouteStackTest extends TestCase
     {
         $stack = new TreeRouteStack();
         $stack->addRoute('foo', new Hostname('example.com'));
-        $uri   = new HttpUri();
+        $uri = new HttpUri();
         $uri->setScheme('http');
 
         $this->assertEquals('http://example.com/', $stack->assemble([], ['name' => 'foo', 'uri' => $uri]));
@@ -153,7 +149,7 @@ class TreeRouteStackTest extends TestCase
     {
         $stack = new TreeRouteStack();
         $stack->addRoute('foo', new Hostname('example.com'));
-        $uri   = new HttpUri();
+        $uri = new HttpUri();
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Request URI has not been set');
@@ -162,7 +158,7 @@ class TreeRouteStackTest extends TestCase
 
     public function testAssembleCanonicalUriWithHostnameRouteAndRequestUriWithoutScheme()
     {
-        $uri   = new HttpUri();
+        $uri = new HttpUri();
         $uri->setScheme('http');
         $stack = new TreeRouteStack();
         $stack->setRequestUri($uri);
@@ -177,7 +173,7 @@ class TreeRouteStackTest extends TestCase
         $stack->addRoute(
             'index',
             [
-                'type' => 'Literal',
+                'type'    => 'Literal',
                 'options' => [
                     'route' => '/',
                 ],
@@ -193,7 +189,7 @@ class TreeRouteStackTest extends TestCase
         $stack->addRoute(
             'index',
             [
-                'type' => 'Literal',
+                'type'    => 'Literal',
                 'options' => [
                     'route' => '/this%2Fthat',
                 ],
@@ -209,7 +205,7 @@ class TreeRouteStackTest extends TestCase
         $stack->addRoute(
             'index',
             [
-                'type' => 'Literal',
+                'type'    => 'Literal',
                 'options' => [
                     'route' => '/this%2Fthat',
                 ],
@@ -224,7 +220,7 @@ class TreeRouteStackTest extends TestCase
 
     public function testAssembleWithScheme()
     {
-        $uri   = new HttpUri();
+        $uri = new HttpUri();
         $uri->setScheme('http');
         $uri->setHost('example.com');
         $stack = new TreeRouteStack();
@@ -232,15 +228,15 @@ class TreeRouteStackTest extends TestCase
         $stack->addRoute(
             'secure',
             [
-                'type' => 'Scheme',
-                'options' => [
-                    'scheme' => 'https'
+                'type'         => 'Scheme',
+                'options'      => [
+                    'scheme' => 'https',
                 ],
                 'child_routes' => [
                     'index' => [
                         'type'    => 'Literal',
                         'options' => [
-                            'route'    => '/',
+                            'route' => '/',
                         ],
                     ],
                 ],
@@ -255,7 +251,7 @@ class TreeRouteStackTest extends TestCase
         $stack->addRoute(
             'index',
             [
-                'type' => 'Literal',
+                'type'    => 'Literal',
                 'options' => [
                     'route' => '/',
                 ],
@@ -289,7 +285,7 @@ class TreeRouteStackTest extends TestCase
         $stack->addRoute(
             'index',
             [
-                'type' => 'Literal',
+                'type'    => 'Literal',
                 'options' => [
                     'route' => '/',
                 ],
@@ -361,20 +357,20 @@ class TreeRouteStackTest extends TestCase
         $stack = new TreeRouteStack();
         $stack->addRoutes([
             'foo' => [
-                'type' => 'Literal',
-                'priority' => 1000,
-                'options' => [
-                    'route' => '/foo',
+                'type'          => 'Literal',
+                'priority'      => 1000,
+                'options'       => [
+                    'route'    => '/foo',
                     'defaults' => [
                         'controller' => 'foo',
                     ],
                 ],
                 'may_terminate' => true,
-                'child_routes' => [
+                'child_routes'  => [
                     'bar' => [
-                        'type' => 'Literal',
+                        'type'    => 'Literal',
                         'options' => [
-                            'route' => '/bar',
+                            'route'    => '/bar',
                             'defaults' => [
                                 'controller' => 'foo',
                                 'action'     => 'bar',
@@ -385,7 +381,7 @@ class TreeRouteStackTest extends TestCase
             ],
         ]);
 
-        $reflectedClass    = new \ReflectionClass($stack);
+        $reflectedClass    = new ReflectionClass($stack);
         $reflectedProperty = $reflectedClass->getProperty('routes');
         $reflectedProperty->setAccessible(true);
         $routes = $reflectedProperty->getValue($stack);
@@ -414,12 +410,12 @@ class TreeRouteStackTest extends TestCase
         $stack->addRoute(
             'foo',
             [
-                'type' => 'literal',
-                'options' => [
-                    'route' => '/foo'
+                'type'         => 'literal',
+                'options'      => [
+                    'route' => '/foo',
                 ],
                 'chain_routes' => [
-                    'bar'
+                    'bar',
                 ],
             ]
         );
@@ -430,28 +426,28 @@ class TreeRouteStackTest extends TestCase
     {
         $stack = new TreeRouteStack();
 
-        $uri = new \Laminas\Uri\Http();
+        $uri = new HttpUri();
         $uri->setHost('localhost');
 
         $stack->setRequestUri($uri);
         $stack->addRoute(
             'foo',
             [
-                'type' => 'literal',
-                'options' => [
-                    'route' => '/foo'
+                'type'         => 'literal',
+                'options'      => [
+                    'route' => '/foo',
                 ],
                 'chain_routes' => [
-                    ['type' => 'scheme', 'options' => ['scheme' => 'https']]
+                    ['type' => 'scheme', 'options' => ['scheme' => 'https']],
                 ],
                 'child_routes' => [
                     'baz' => [
-                        'type' => 'literal',
+                        'type'    => 'literal',
                         'options' => [
-                            'route' => '/baz'
+                            'route' => '/baz',
                         ],
-                    ]
-                ]
+                    ],
+                ],
             ]
         );
         $this->assertEquals('https://localhost/foo/baz', $stack->assemble([], ['name' => 'foo/baz']));

--- a/test/Http/WildcardTest.php
+++ b/test/Http/WildcardTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace LaminasTest\Router\Http;
@@ -16,90 +10,102 @@ use Laminas\Router\Http\Wildcard;
 use Laminas\Stdlib\Request as BaseRequest;
 use LaminasTest\Router\FactoryTester;
 use PHPUnit\Framework\TestCase;
+use Some\ConnectMiddleware;
+use Some\Handler;
+
+use function strlen;
+use function strpos;
 
 class WildcardTest extends TestCase
 {
-    public static function routeProvider()
+    /**
+     * @psalm-return array<string, array{
+     *     0: Wildcard,
+     *     1: string,
+     *     2: null|int,
+     *     3: array<string, string|int|float>
+     * }>
+     */
+    public static function routeProvider(): array
     {
         return [
-            'simple-match' => [
+            'simple-match'                       => [
                 new Wildcard(),
                 '/foo/bar/baz/bat',
                 null,
-                ['foo' => 'bar', 'baz' => 'bat']
+                ['foo' => 'bar', 'baz' => 'bat'],
             ],
-            'empty-match' => [
+            'empty-match'                        => [
                 new Wildcard(),
                 '',
                 null,
-                []
+                [],
             ],
             'no-match-without-leading-delimiter' => [
                 new Wildcard(),
                 '/foo/foo/bar/baz/bat',
                 5,
-                null
+                null,
             ],
-            'no-match-with-trailing-slash' => [
+            'no-match-with-trailing-slash'       => [
                 new Wildcard(),
                 '/foo/bar/baz/bat/',
                 null,
-                null
+                null,
             ],
-            'match-overrides-default' => [
+            'match-overrides-default'            => [
                 new Wildcard('/', '/', ['foo' => 'baz']),
                 '/foo/bat',
                 null,
-                ['foo' => 'bat']
+                ['foo' => 'bat'],
             ],
-            'offset-skips-beginning' => [
+            'offset-skips-beginning'             => [
                 new Wildcard(),
                 '/bat/foo/bar',
                 4,
-                ['foo' => 'bar']
+                ['foo' => 'bar'],
             ],
-            'non-standard-key-value-delimiter' => [
+            'non-standard-key-value-delimiter'   => [
                 new Wildcard('-'),
                 '/foo-bar/baz-bat',
                 null,
-                ['foo' => 'bar', 'baz' => 'bat']
+                ['foo' => 'bar', 'baz' => 'bat'],
             ],
-            'non-standard-parameter-delimiter' => [
+            'non-standard-parameter-delimiter'   => [
                 new Wildcard('/', '-'),
                 '/foo/-foo/bar-baz/bat',
                 5,
-                ['foo' => 'bar', 'baz' => 'bat']
+                ['foo' => 'bar', 'baz' => 'bat'],
             ],
             'empty-values-with-non-standard-key-value-delimiter-are-omitted' => [
                 new Wildcard('-'),
                 '/foo',
                 null,
                 [],
-                true
+                true,
             ],
-            'url-encoded-parameters-are-decoded' => [
+            'url-encoded-parameters-are-decoded'                             => [
                 new Wildcard(),
                 '/foo/foo%20bar',
                 null,
-                ['foo' => 'foo bar']
+                ['foo' => 'foo bar'],
             ],
-            'params-contain-non-string-scalar-values' => [
+            'params-contain-non-string-scalar-values'                        => [
                 new Wildcard(),
                 '/int_param/42/float_param/4.2',
                 null,
-                ['int_param' => 42, 'float_param' => 4.2]
+                ['int_param' => 42, 'float_param' => 4.2],
             ],
         ];
     }
 
     /**
      * @dataProvider routeProvider
-     * @param        Wildcard $route
      * @param        string   $path
-     * @param        int      $offset
+     * @param        int|null $offset
      * @param        array    $params
      */
-    public function testMatching(Wildcard $route, $path, $offset, array $params = null)
+    public function testMatching(Wildcard $route, $path, $offset, ?array $params = null)
     {
         $request = new Request();
         $request->setUri('http://example.com' . $path);
@@ -122,13 +128,12 @@ class WildcardTest extends TestCase
 
     /**
      * @dataProvider routeProvider
-     * @param        Wildcard $route
      * @param        string   $path
-     * @param        int      $offset
+     * @param        int|null $offset
      * @param        array    $params
      * @param        boolean  $skipAssembling
      */
-    public function testAssembling(Wildcard $route, $path, $offset, array $params = null, $skipAssembling = false)
+    public function testAssembling(Wildcard $route, $path, $offset, ?array $params = null, $skipAssembling = false)
     {
         if ($params === null || $skipAssembling) {
             // Data which will not match are not tested for assembling.
@@ -175,39 +180,40 @@ class WildcardTest extends TestCase
     {
         // verify all characters which don't absolutely require encoding pass through match unchanged
         // this includes every character other than #, %, / and ?
-        $raw = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`-=[]\\;\',.~!@$^&*()_+{}|:"<>';
+        $raw     = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`-=[]\\;\',.~!@$^&*()_+{}|:"<>';
         $request = new Request();
         $request->setUri('http://example.com/foo/' . $raw);
-        $route   = new Wildcard();
-        $match   = $route->match($request);
+        $route = new Wildcard();
+        $match = $route->match($request);
 
         $this->assertSame($raw, $match->getParam('foo'));
     }
 
     public function testEncodedDecode()
     {
-        // @codingStandardsIgnoreStart
+        // @phpcs:disable Generic.Files.LineLength.TooLong
         // every character
         $in  = '%61%62%63%64%65%66%67%68%69%6a%6b%6c%6d%6e%6f%70%71%72%73%74%75%76%77%78%79%7a%41%42%43%44%45%46%47%48%49%4a%4b%4c%4d%4e%4f%50%51%52%53%54%55%56%57%58%59%5a%30%31%32%33%34%35%36%37%38%39%60%2d%3d%5b%5d%5c%3b%27%2c%2e%2f%7e%21%40%23%24%25%5e%26%2a%28%29%5f%2b%7b%7d%7c%3a%22%3c%3e%3f';
         $out = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`-=[]\\;\',./~!@#$%^&*()_+{}|:"<>?';
-        // @codingStandardsIgnoreEnd
+        // @phpcs:enable Generic.Files.LineLength.TooLong
 
         $request = new Request();
         $request->setUri('http://example.com/foo/' . $in);
-        $route   = new Wildcard();
-        $match   = $route->match($request);
+        $route = new Wildcard();
+        $match = $route->match($request);
 
         $this->assertSame($out, $match->getParam('foo'));
     }
 
     public function testPathAssemblyShouldSkipAnyNonScalarValues()
     {
+        /** @psalm-suppress DeprecatedClass */
         $route = new Wildcard('/', '/', [
-            'action' => 'index',
+            'action'     => 'index',
             'controller' => 'index',
             'middleware' => [
-                \Some\ConnectMiddleware::class,
-                \Some\Handler::class,
+                ConnectMiddleware::class,
+                Handler::class,
             ],
         ]);
 

--- a/test/PriorityListTest.php
+++ b/test/PriorityListTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace LaminasTest\Router;
@@ -13,11 +7,12 @@ namespace LaminasTest\Router;
 use Laminas\Router\PriorityList;
 use PHPUnit\Framework\TestCase;
 
+use function array_keys;
+use function iterator_to_array;
+
 class PriorityListTest extends TestCase
 {
-    /**
-     * @var PriorityList
-     */
+    /** @var PriorityList */
     protected $list;
 
     public function setUp(): void

--- a/test/RouteMatchTest.php
+++ b/test/RouteMatchTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace LaminasTest\Router;

--- a/test/RoutePluginManagerFactoryTest.php
+++ b/test/RoutePluginManagerFactoryTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace LaminasTest\Router;
@@ -15,23 +9,20 @@ use Laminas\Router\RouteInterface;
 use Laminas\Router\RoutePluginManager;
 use Laminas\Router\RoutePluginManagerFactory;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class RoutePluginManagerFactoryTest extends TestCase
 {
-    /**
-     * @var ContainerInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
+    /** @var ContainerInterface|MockObject */
     private $container;
-    /**
-     * @var RoutePluginManagerFactory
-     */
+    /** @var RoutePluginManagerFactory */
     private $factory;
 
     public function setUp(): void
     {
         $this->container = $this->createMock(ContainerInterface::class);
-        $this->factory = new RoutePluginManagerFactory();
+        $this->factory   = new RoutePluginManagerFactory();
     }
 
     public function testInvocationReturnsAPluginManager()
@@ -50,11 +41,13 @@ class RoutePluginManagerFactoryTest extends TestCase
 
     public function testInvocationCanProvideOptionsToThePluginManager()
     {
-        $options = ['factories' => [
-            'TestRoute' => function ($container) {
-                return $this->createMock(RouteInterface::class);
-            },
-        ]];
+        $options = [
+            'factories' => [
+                'TestRoute' => function ($container) {
+                    return $this->createMock(RouteInterface::class);
+                },
+            ],
+        ];
         $plugins = $this->factory->__invoke(
             $this->container,
             RoutePluginManager::class,

--- a/test/RoutePluginManagerTest.php
+++ b/test/RoutePluginManagerTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace LaminasTest\Router;
@@ -26,10 +20,12 @@ class RoutePluginManagerTest extends TestCase
 
     public function testCanLoadAnyRoute()
     {
-        $routes = new RoutePluginManager(new ServiceManager(), ['invokables' => [
-            'DummyRoute' => TestAsset\DummyRoute::class,
-        ]]);
-        $route = $routes->get('DummyRoute');
+        $routes = new RoutePluginManager(new ServiceManager(), [
+            'invokables' => [
+                'DummyRoute' => TestAsset\DummyRoute::class,
+            ],
+        ]);
+        $route  = $routes->get('DummyRoute');
 
         $this->assertInstanceOf(TestAsset\DummyRoute::class, $route);
     }

--- a/test/RouterFactoryTest.php
+++ b/test/RouterFactoryTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace LaminasTest\Router;
@@ -16,6 +10,8 @@ use Laminas\Router\RouterFactory;
 use Laminas\ServiceManager\Config;
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase;
+
+use function array_merge_recursive;
 
 class RouterFactoryTest extends TestCase
 {
@@ -30,17 +26,19 @@ class RouterFactoryTest extends TestCase
             ],
         ];
 
-        $this->factory  = new RouterFactory();
+        $this->factory = new RouterFactory();
     }
 
     public function testFactoryCanCreateRouterBasedOnConfiguredName()
     {
-        $config = new Config(array_merge_recursive($this->defaultServiceConfig, [
-            'services' => [ 'config' => [
-                'router' => [
-                    'router_class' => TestAsset\Router::class,
+        $config   = new Config(array_merge_recursive($this->defaultServiceConfig, [
+            'services' => [
+                'config' => [
+                    'router' => [
+                        'router_class' => TestAsset\Router::class,
+                    ],
                 ],
-            ]],
+            ],
         ]));
         $services = new ServiceManager();
         $config->configureServiceManager($services);
@@ -51,12 +49,14 @@ class RouterFactoryTest extends TestCase
 
     public function testFactoryCanCreateRouterWhenOnlyHttpRouterConfigPresent()
     {
-        $config = new Config(array_merge_recursive($this->defaultServiceConfig, [
-            'services' => [ 'config' => [
-                'router' => [
-                    'router_class' => TestAsset\Router::class,
+        $config   = new Config(array_merge_recursive($this->defaultServiceConfig, [
+            'services' => [
+                'config' => [
+                    'router' => [
+                        'router_class' => TestAsset\Router::class,
+                    ],
                 ],
-            ]],
+            ],
         ]));
         $services = new ServiceManager();
         $config->configureServiceManager($services);

--- a/test/SimpleRouteStackTest.php
+++ b/test/SimpleRouteStackTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace LaminasTest\Router;
@@ -44,7 +38,7 @@ class SimpleRouteStackTest extends TestCase
     {
         $stack = new SimpleRouteStack();
         $stack->addRoutes([
-            'foo' => new TestAsset\DummyRoute()
+            'foo' => new TestAsset\DummyRoute(),
         ]);
 
         $this->assertInstanceOf(RouteMatch::class, $stack->match(new Request()));
@@ -54,7 +48,7 @@ class SimpleRouteStackTest extends TestCase
     {
         $stack = new SimpleRouteStack();
         $stack->addRoutes(new ArrayIterator([
-            'foo' => new TestAsset\DummyRoute()
+            'foo' => new TestAsset\DummyRoute(),
         ]));
 
         $this->assertInstanceOf(RouteMatch::class, $stack->match(new Request()));
@@ -73,7 +67,7 @@ class SimpleRouteStackTest extends TestCase
     {
         $stack = new SimpleRouteStack();
         $stack->setRoutes([
-            'foo' => new TestAsset\DummyRoute()
+            'foo' => new TestAsset\DummyRoute(),
         ]);
 
         $this->assertInstanceOf(RouteMatch::class, $stack->match(new Request()));
@@ -87,7 +81,7 @@ class SimpleRouteStackTest extends TestCase
     {
         $stack = new SimpleRouteStack();
         $stack->setRoutes(new ArrayIterator([
-            'foo' => new TestAsset\DummyRoute()
+            'foo' => new TestAsset\DummyRoute(),
         ]));
 
         $this->assertInstanceOf(RouteMatch::class, $stack->match(new Request()));
@@ -101,7 +95,7 @@ class SimpleRouteStackTest extends TestCase
     {
         $stack = new SimpleRouteStack();
         $stack->addRoutes([
-            'foo' => new TestAsset\DummyRoute()
+            'foo' => new TestAsset\DummyRoute(),
         ]);
 
         $this->assertEquals($stack, $stack->removeRoute('foo'));
@@ -121,7 +115,7 @@ class SimpleRouteStackTest extends TestCase
     {
         $stack = new SimpleRouteStack();
         $stack->addRoute('foo', [
-            'type' => TestAsset\DummyRoute::class
+            'type' => TestAsset\DummyRoute::class,
         ]);
 
         $this->assertInstanceOf(RouteMatch::class, $stack->match(new Request()));
@@ -132,7 +126,7 @@ class SimpleRouteStackTest extends TestCase
         $stack = new SimpleRouteStack();
         $stack->addRoute('foo', [
             'type'    => TestAsset\DummyRoute::class,
-            'options' => []
+            'options' => [],
         ]);
 
         $this->assertInstanceOf(RouteMatch::class, $stack->match(new Request()));
@@ -153,10 +147,10 @@ class SimpleRouteStackTest extends TestCase
 
         $stack->addRoute('foo', [
             'type'     => TestAsset\DummyRouteWithParam::class,
-            'priority' => 2
+            'priority' => 2,
         ])->addRoute('bar', [
             'type'     => TestAsset\DummyRoute::class,
-            'priority' => 1
+            'priority' => 1,
         ]);
 
         $this->assertEquals('bar', $stack->match(new Request())->getParam('foo'));
@@ -166,13 +160,13 @@ class SimpleRouteStackTest extends TestCase
     {
         $stack = new SimpleRouteStack();
 
-        $route = new TestAsset\DummyRouteWithParam();
+        $route           = new TestAsset\DummyRouteWithParam();
         $route->priority = 2;
         $stack->addRoute('baz', $route);
 
         $stack->addRoute('foo', [
             'type'     => TestAsset\DummyRoute::class,
-            'priority' => 1
+            'priority' => 1,
         ]);
 
         $this->assertEquals('bar', $stack->match(new Request())->getParam('foo'));
@@ -182,7 +176,7 @@ class SimpleRouteStackTest extends TestCase
     {
         $stack = new SimpleRouteStack();
         $stack->addRoute('foo', new ArrayIterator([
-            'type' => TestAsset\DummyRoute::class
+            'type' => TestAsset\DummyRoute::class,
         ]));
 
         $this->assertInstanceOf(RouteMatch::class, $stack->match(new Request()));
@@ -258,7 +252,7 @@ class SimpleRouteStackTest extends TestCase
             [
                 'route_plugins'  => new RoutePluginManager(new ServiceManager()),
                 'routes'         => [],
-                'default_params' => []
+                'default_params' => [],
             ]
         );
     }

--- a/test/TestAsset/DummyRoute.php
+++ b/test/TestAsset/DummyRoute.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace LaminasTest\Router\TestAsset;
@@ -13,6 +7,7 @@ namespace LaminasTest\Router\TestAsset;
 use Laminas\Router\RouteInterface;
 use Laminas\Router\RouteMatch;
 use Laminas\Stdlib\RequestInterface;
+use Traversable;
 
 /**
  * Dummy route.
@@ -23,7 +18,7 @@ class DummyRoute implements RouteInterface
      * match(): defined by RouteInterface interface.
      *
      * @see    Route::match()
-     * @param  RequestInterface $request
+     *
      * @return RouteMatch
      */
     public function match(RequestInterface $request)
@@ -35,11 +30,12 @@ class DummyRoute implements RouteInterface
      * assemble(): defined by RouteInterface interface.
      *
      * @see    Route::assemble()
+     *
      * @param  array $params
      * @param  array $options
      * @return mixed
      */
-    public function assemble(array $params = null, array $options = null)
+    public function assemble(?array $params = null, ?array $options = null)
     {
         return '';
     }
@@ -47,7 +43,7 @@ class DummyRoute implements RouteInterface
     /**
      * factory(): defined by RouteInterface interface
      *
-     * @param  array|\Traversable $options
+     * @param array|Traversable $options
      * @return DummyRoute
      */
     public static function factory($options = [])

--- a/test/TestAsset/DummyRouteWithParam.php
+++ b/test/TestAsset/DummyRouteWithParam.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
-
 declare(strict_types=1);
 
 namespace LaminasTest\Router\TestAsset;
@@ -22,7 +16,7 @@ class DummyRouteWithParam extends DummyRoute
      * match(): defined by RouteInterface interface.
      *
      * @see    Route::match()
-     * @param  RequestInterface $request
+     *
      * @return RouteMatch
      */
     public function match(RequestInterface $request)
@@ -34,11 +28,12 @@ class DummyRouteWithParam extends DummyRoute
      * assemble(): defined by RouteInterface interface.
      *
      * @see    Route::assemble()
+     *
      * @param  array $params
      * @param  array $options
      * @return mixed
      */
-    public function assemble(array $params = null, array $options = null)
+    public function assemble(?array $params = null, ?array $options = null)
     {
         if (isset($params['foo'])) {
             return $params['foo'];

--- a/test/TestAsset/Router.php
+++ b/test/TestAsset/Router.php
@@ -1,10 +1,4 @@
-<?php
-
-/**
- * @see       https://github.com/laminas/laminas-router for the canonical source repository
- * @copyright https://github.com/laminas/laminas-router/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-router/blob/master/LICENSE.md New BSD License
- */
+<?php // phpcs:disable Squiz.Commenting.FunctionComment.InvalidNoReturn
 
 declare(strict_types=1);
 
@@ -12,14 +6,15 @@ namespace LaminasTest\Router\TestAsset;
 
 use Laminas\Router\RouteStackInterface;
 use Laminas\Stdlib\RequestInterface as Request;
+use Traversable;
 
 class Router implements RouteStackInterface
 {
     /**
      * Create a new route with given options.
      *
-     * @param  array|\Traversable $options
-     * @return void
+     * @param array|Traversable $options
+     * @return self
      */
     public static function factory($options = [])
     {
@@ -29,7 +24,6 @@ class Router implements RouteStackInterface
     /**
      * Match a given request.
      *
-     * @param  Request $request
      * @return RouteMatch|null
      */
     public function match(Request $request)
@@ -62,7 +56,7 @@ class Router implements RouteStackInterface
     /**
      * Add multiple routes to the stack.
      *
-     * @param  array|\Traversable $routes
+     * @param array|Traversable $routes
      * @return RouteStackInterface
      */
     public function addRoutes($routes)
@@ -82,7 +76,7 @@ class Router implements RouteStackInterface
     /**
      * Remove all routes from the stack and set new ones.
      *
-     * @param  array|\Traversable $routes
+     * @param array|Traversable $routes
      * @return RouteStackInterface
      */
     public function setRoutes($routes)


### PR DESCRIPTION
This patch updates the laminas-coding-standard version to the 2.2 series and applies its rules.

Replaces #29
