### PR TITLE
Adds priority member variable to prevent runtime dynamic property declaration 

### DIFF
--- a/src/Http/Part.php
+++ b/src/Http/Part.php
@@ -46,6 +46,13 @@ class Part extends TreeRouteStack implements RouteInterface
     protected $childRoutes;
 
     /**
+     * Priority.
+     *
+     * @var int|null
+     */
+    public $priority;
+
+    /**
      * Create a new part route.
      *
      * @param  mixed              $route

--- a/src/Http/Part.php
+++ b/src/Http/Part.php
@@ -49,6 +49,7 @@ class Part extends TreeRouteStack implements RouteInterface
      * Priority.
      *
      * @var int|null
+     * @internal For internal classes only. Not designed for general use.
      */
     public $priority;
 

--- a/src/Http/Part.php
+++ b/src/Http/Part.php
@@ -47,9 +47,9 @@ class Part extends TreeRouteStack implements RouteInterface
 
     /**
      * Priority.
+     * @internal For internal classes only. Not designed for general use.
      *
      * @var int|null
-     * @internal For internal classes only. Not designed for general use.
      */
     public $priority;
 

--- a/src/Http/Part.php
+++ b/src/Http/Part.php
@@ -47,6 +47,7 @@ class Part extends TreeRouteStack implements RouteInterface
 
     /**
      * Priority.
+     *
      * @internal For internal classes only. Not designed for general use.
      *
      * @var int|null


### PR DESCRIPTION
Previously a dynamic property was used which is now deprecated in PHP 8.2.

Signed-off-by: Mathias Berchtold <mberchtold@gmail.com>

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes (for PHP 8.2)
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

Fixes #39