### PR TITLE
Document and deprecate undeclared priority property

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -726,8 +726,8 @@
     <MissingClosureParamType occurrences="1">
       <code>$services</code>
     </MissingClosureParamType>
-    <MissingClosureReturnType occurrences="2">
-      <code>static fn($services)</code>
+    <MissingClosureReturnType occurrences="1">
+      <code>static fn($services) =&gt; new RoutePluginManager($services)</code>
     </MissingClosureReturnType>
     <MixedArgument occurrences="1">
       <code>$services</code>
@@ -1038,8 +1038,8 @@
     <MissingClosureParamType occurrences="1">
       <code>$container</code>
     </MissingClosureParamType>
-    <MissingClosureReturnType occurrences="2">
-      <code>fn($container)</code>
+    <MissingClosureReturnType occurrences="1">
+      <code>fn($container) =&gt; $this-&gt;createMock(RouteInterface::class)</code>
     </MissingClosureReturnType>
     <MissingReturnType occurrences="3">
       <code>testCreateServiceReturnsAPluginManager</code>
@@ -1065,8 +1065,8 @@
     <MissingClosureParamType occurrences="1">
       <code>$services</code>
     </MissingClosureParamType>
-    <MissingClosureReturnType occurrences="2">
-      <code>static fn($services)</code>
+    <MissingClosureReturnType occurrences="1">
+      <code>static fn($services) =&gt; new RoutePluginManager($services)</code>
     </MissingClosureReturnType>
     <MixedArgument occurrences="1">
       <code>$services</code>
@@ -1076,6 +1076,9 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>'Traversable'</code>
     </ArgumentTypeCoercion>
+    <DeprecatedProperty occurrences="1">
+      <code>$route-&gt;priority</code>
+    </DeprecatedProperty>
     <InvalidArgument occurrences="2">
       <code>'foo'</code>
       <code>'foo'</code>
@@ -1114,9 +1117,6 @@
       <code>getParam</code>
       <code>getParam</code>
     </PossiblyNullReference>
-    <UndefinedPropertyAssignment occurrences="1">
-      <code>$route-&gt;priority</code>
-    </UndefinedPropertyAssignment>
   </file>
   <file src="test/TestAsset/DummyRoute.php">
     <UnsafeInstantiation occurrences="1">

--- a/src/Http/Literal.php
+++ b/src/Http/Literal.php
@@ -35,6 +35,14 @@ class Literal implements RouteInterface
     protected $defaults;
 
     /**
+     * @internal
+     * @deprecated Since 3.9.0 This property will be removed or made private in version 4.0
+     *
+     * @var int|null
+     */
+    public $priority;
+
+    /**
      * Create a new literal route.
      *
      * @param  string $route

--- a/src/Http/Part.php
+++ b/src/Http/Part.php
@@ -49,6 +49,7 @@ class Part extends TreeRouteStack implements RouteInterface
      * Priority.
      *
      * @internal For internal classes only. Not designed for general use.
+     * @deprecated Since 3.9.0 This property will be removed or made private in version 4.0
      *
      * @var int|null
      */

--- a/test/TestAsset/DummyRoute.php
+++ b/test/TestAsset/DummyRoute.php
@@ -14,6 +14,9 @@ use Traversable;
  */
 class DummyRoute implements RouteInterface
 {
+    /** @deprecated Setting priority with a public property should be factored out in the next major */
+    public ?int $priority = null;
+
     /**
      * match(): defined by RouteInterface interface.
      *


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes - for 8.2

### Description

#40 did not cover all the reads/writes of `$priority` to the various Route types. This patch adds the public property to 2 more types and immediately deprecates them.

