### PR TITLE
Drop incorrect and never encountered token in Hostname route definition

### DIFF
--- a/src/Http/Hostname.php
+++ b/src/Http/Hostname.php
@@ -149,7 +149,7 @@ class Hostname implements RouteInterface
         $level      = 0;
 
         while ($currentPos < $length) {
-            if (! preg_match('(\G(?P<literal>[a-z0-9-.]*)(?P<token>[:{\[\]]|$))', $def, $matches, 0, $currentPos)) {
+            if (! preg_match('(\G(?P<literal>[a-z0-9-.]*)(?P<token>[:\[\]]|$))', $def, $matches, 0, $currentPos)) {
                 throw new Exception\RuntimeException('Matched hostname literal contains a disallowed character');
             }
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Hostname route regex for parsing route definition looks for one of the tokens `:`, `[`, `]`, or `{` where `:` denoting a parameter and `[` and `]` are denoting optional segment. `{` is not a valid character in hostname route definition and as such can never be encountered except as a typo, eg `{optional.]hostname.tld`

This change will not affect any users.