### PR TITLE
fix #91 : Introduce HttpRouteInterface and deprecate Http\RouteInterface

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.13.1@1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51">
+<files psalm-version="6.15.1@28dc127af1b5aecd52314f6f645bafc10d0e11f9">
   <file src="src/Http/Chain.php">
     <InvalidReturnStatement>
       <code><![CDATA[new static(
@@ -280,6 +280,11 @@
     <UnsafeInstantiation>
       <code><![CDATA[new static($options['regex'], $options['spec'], $options['defaults'])]]></code>
     </UnsafeInstantiation>
+  </file>
+  <file src="src/Http/RouteInterface.php">
+    <UnusedClass>
+      <code><![CDATA[RouteInterface]]></code>
+    </UnusedClass>
   </file>
   <file src="src/Http/RouteMatch.php">
     <DocblockTypeContradiction>
@@ -910,7 +915,7 @@
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
     <MoreSpecificReturnType>
-      <code><![CDATA[RoutePluginManager<RouteInterface>]]></code>
+      <code><![CDATA[RoutePluginManager<HttpRouteInterface>]]></code>
     </MoreSpecificReturnType>
     <PossiblyInvalidArgument>
       <code><![CDATA[testAssembling]]></code>

--- a/src/Http/Chain.php
+++ b/src/Http/Chain.php
@@ -7,6 +7,7 @@ namespace Laminas\Router\Http;
 use ArrayObject;
 use Laminas\Router\Exception;
 use Laminas\Router\PriorityList;
+use Laminas\Router\RouteInterface;
 use Laminas\Router\RoutePluginManager;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
@@ -24,10 +25,10 @@ use function sprintf;
 use function strlen;
 
 /**
- * @template TRoute of RouteInterface
+ * @template TRoute of HttpRouteInterface
  * @template-extends TreeRouteStack<TRoute>
  */
-class Chain extends TreeRouteStack implements RouteInterface
+class Chain extends TreeRouteStack implements HttpRouteInterface
 {
     /**
      * Chain routes.
@@ -61,7 +62,7 @@ class Chain extends TreeRouteStack implements RouteInterface
     /**
      * factory(): defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::factory()
+     * @see    RouteInterface::factory()
      *
      * @param  mixed $options
      * @throws Exception\InvalidArgumentException
@@ -104,7 +105,7 @@ class Chain extends TreeRouteStack implements RouteInterface
     /**
      * match(): defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::match()
+     * @see    RouteInterface::match()
      *
      * @param  int|null $pathOffset
      * @return RouteMatch|null
@@ -132,7 +133,7 @@ class Chain extends TreeRouteStack implements RouteInterface
         $pathLength = strlen($uri->getPath());
 
         foreach ($this->routes as $route) {
-            assert($route instanceof RouteInterface);
+            assert($route instanceof HttpRouteInterface);
             $subMatch = $route->match($request, $pathOffset, $options);
 
             if ($subMatch === null) {
@@ -153,7 +154,7 @@ class Chain extends TreeRouteStack implements RouteInterface
     /**
      * assemble(): Defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::assemble()
+     * @see    RouteInterface::assemble()
      *
      * @return mixed
      */
@@ -188,7 +189,7 @@ class Chain extends TreeRouteStack implements RouteInterface
     /**
      * getAssembledParams(): defined by RouteInterface interface.
      *
-     * @see    RouteInterface::getAssembledParams
+     * @see    HttpRouteInterface::getAssembledParams
      *
      * @return array
      */

--- a/src/Http/Hostname.php
+++ b/src/Http/Hostname.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Router\Http;
 
 use Laminas\Router\Exception;
+use Laminas\Router\RouteInterface;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
 use Laminas\Uri\UriInterface;
@@ -39,7 +40,7 @@ use function strlen;
  *     }
  * >
  */
-class Hostname implements RouteInterface
+class Hostname implements HttpRouteInterface
 {
     /**
      * Parts of the route.
@@ -99,7 +100,7 @@ class Hostname implements RouteInterface
     /**
      * factory(): defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::factory()
+     * @see    RouteInterface::factory()
      *
      * @param  iterable $options
      * @return Hostname
@@ -308,7 +309,7 @@ class Hostname implements RouteInterface
     /**
      * match(): defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::match()
+     * @see    RouteInterface::match()
      *
      * @return RouteMatch|null
      */
@@ -342,7 +343,7 @@ class Hostname implements RouteInterface
     /**
      * assemble(): Defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::assemble()
+     * @see    RouteInterface::assemble()
      *
      * @return mixed
      */
@@ -365,9 +366,9 @@ class Hostname implements RouteInterface
     }
 
     /**
-     * getAssembledParams(): defined by RouteInterface interface.
+     * getAssembledParams(): defined by HttpRouteInterface interface.
      *
-     * @see    RouteInterface::getAssembledParams
+     * @see    HttpRouteInterface::getAssembledParams
      *
      * @return list<string>
      */

--- a/src/Http/HttpRouteInterface.php
+++ b/src/Http/HttpRouteInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Router\Http;
+
+use Laminas\Router\RouteInterface;
+use Laminas\Stdlib\RequestInterface as Request;
+
+/**
+ * Tree specific route interface.
+ *
+ * Note: the additional {@see self::match()} annotation is only here for documentation purposes, because we cannot
+ *       change the signature of {@see self::match()} in the interface definition without breaking BC.
+ *
+ * @method RouteMatch|null match(Request $request, int|null $pathOffset = null, array $options = [])
+ */
+interface HttpRouteInterface extends RouteInterface
+{
+    /**
+     * Get a list of parameters used while assembling.
+     *
+     * @return array
+     */
+    public function getAssembledParams();
+}

--- a/src/Http/Literal.php
+++ b/src/Http/Literal.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Router\Http;
 
 use Laminas\Router\Exception;
+use Laminas\Router\RouteInterface;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
 use Traversable;
@@ -18,7 +19,7 @@ use function strpos;
 /**
  * Literal route.
  */
-class Literal implements RouteInterface
+class Literal implements HttpRouteInterface
 {
     /**
      * Default values.
@@ -53,7 +54,7 @@ class Literal implements RouteInterface
     /**
      * factory(): defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::factory()
+     * @see    RouteInterface::factory()
      *
      * @param  iterable $options
      * @return Literal
@@ -84,7 +85,7 @@ class Literal implements RouteInterface
     /**
      * match(): defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::match()
+     * @see    RouteInterface::match()
      *
      * @param  integer|null $pathOffset
      * @return RouteMatch|null
@@ -118,7 +119,7 @@ class Literal implements RouteInterface
     /**
      * assemble(): Defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::assemble()
+     * @see    RouteInterface::assemble()
      *
      * @return mixed
      */
@@ -128,9 +129,9 @@ class Literal implements RouteInterface
     }
 
     /**
-     * getAssembledParams(): defined by RouteInterface interface.
+     * getAssembledParams(): defined by HttpRouteInterface interface.
      *
-     * @see    RouteInterface::getAssembledParams
+     * @see    HttpRouteInterface::getAssembledParams
      *
      * @return array
      */

--- a/src/Http/Method.php
+++ b/src/Http/Method.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Router\Http;
 
 use Laminas\Router\Exception;
+use Laminas\Router\RouteInterface;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
 use Traversable;
@@ -20,7 +21,7 @@ use function strtoupper;
 /**
  * Method route.
  */
-class Method implements RouteInterface
+class Method implements HttpRouteInterface
 {
     /**
      * Default values.
@@ -55,7 +56,7 @@ class Method implements RouteInterface
     /**
      * factory(): defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::factory()
+     * @see    RouteInterface::factory()
      *
      * @param  iterable $options
      * @return Method
@@ -86,7 +87,7 @@ class Method implements RouteInterface
     /**
      * match(): defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::match()
+     * @see    RouteInterface::match()
      *
      * @return RouteMatch|null
      */
@@ -110,7 +111,7 @@ class Method implements RouteInterface
     /**
      * assemble(): Defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::assemble()
+     * @see    RouteInterface::assemble()
      *
      * @return mixed
      */
@@ -121,9 +122,9 @@ class Method implements RouteInterface
     }
 
     /**
-     * getAssembledParams(): defined by RouteInterface interface.
+     * getAssembledParams(): defined by HttpRouteInterface interface.
      *
-     * @see    RouteInterface::getAssembledParams
+     * @see    HttpRouteInterface::getAssembledParams
      *
      * @return array
      */

--- a/src/Http/Part.php
+++ b/src/Http/Part.php
@@ -7,6 +7,7 @@ namespace Laminas\Router\Http;
 use ArrayObject;
 use Laminas\Router\Exception;
 use Laminas\Router\PriorityList;
+use Laminas\Router\RouteInterface;
 use Laminas\Router\RoutePluginManager;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
@@ -20,10 +21,10 @@ use function sprintf;
 use function strlen;
 
 /**
- * @template TRoute of RouteInterface
+ * @template TRoute of HttpRouteInterface
  * @template-extends TreeRouteStack<TRoute>
  */
-class Part extends TreeRouteStack implements RouteInterface
+class Part extends TreeRouteStack implements HttpRouteInterface
 {
     /**
      * RouteInterface to match.
@@ -61,7 +62,7 @@ class Part extends TreeRouteStack implements RouteInterface
     ) {
         $this->routePluginManager = $routePlugins;
 
-        if (! $route instanceof RouteInterface) {
+        if (! $route instanceof HttpRouteInterface) {
             $route = $this->routeFromArray($route);
         }
 
@@ -79,7 +80,7 @@ class Part extends TreeRouteStack implements RouteInterface
     /**
      * factory(): defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::factory()
+     * @see    RouteInterface::factory()
      *
      * @param  mixed $options
      * @return Part
@@ -132,7 +133,7 @@ class Part extends TreeRouteStack implements RouteInterface
     /**
      * match(): defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::match()
+     * @see    RouteInterface::match()
      *
      * @param  integer|null $pathOffset
      * @return RouteMatch|null
@@ -183,7 +184,7 @@ class Part extends TreeRouteStack implements RouteInterface
     /**
      * assemble(): Defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::assemble()
+     * @see    RouteInterface::assemble()
      *
      * @return mixed
      * @throws Exception\RuntimeException
@@ -218,9 +219,9 @@ class Part extends TreeRouteStack implements RouteInterface
     }
 
     /**
-     * getAssembledParams(): defined by RouteInterface interface.
+     * getAssembledParams(): defined by HttpRouteInterface interface.
      *
-     * @see    RouteInterface::getAssembledParams
+     * @see    HttpRouteInterface::getAssembledParams
      *
      * @return array
      */

--- a/src/Http/Placeholder.php
+++ b/src/Http/Placeholder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Router\Http;
 
 use Laminas\Router\Exception;
+use Laminas\Router\RouteInterface;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
 use Traversable;
@@ -15,7 +16,7 @@ use function sprintf;
 /**
  * Placeholder route.
  */
-class Placeholder implements RouteInterface
+class Placeholder implements HttpRouteInterface
 {
     /**
      * @internal
@@ -32,7 +33,7 @@ class Placeholder implements RouteInterface
     /**
      * factory(): defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::factory()
+     * @see    RouteInterface::factory()
      *
      * @param  iterable $options
      * @return Placeholder
@@ -65,7 +66,7 @@ class Placeholder implements RouteInterface
     /**
      * match(): defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::match()
+     * @see    RouteInterface::match()
      *
      * @param  integer|null $pathOffset
      * @return RouteMatch|null
@@ -78,7 +79,7 @@ class Placeholder implements RouteInterface
     /**
      * assemble(): Defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::assemble()
+     * @see    RouteInterface::assemble()
      *
      * @return mixed
      */
@@ -90,7 +91,7 @@ class Placeholder implements RouteInterface
     /**
      * getAssembledParams(): defined by RouteInterface interface.
      *
-     * @see    RouteInterface::getAssembledParams
+     * @see    HttpRouteInterface::getAssembledParams
      *
      * @return array
      */

--- a/src/Http/Regex.php
+++ b/src/Http/Regex.php
@@ -6,6 +6,7 @@ namespace Laminas\Router\Http;
 
 use Laminas\Router\Exception;
 use Laminas\Router\Exception\InvalidArgumentException;
+use Laminas\Router\RouteInterface;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
 use Traversable;
@@ -26,7 +27,7 @@ use function strlen;
 /**
  * Regex route.
  */
-class Regex implements RouteInterface
+class Regex implements HttpRouteInterface
 {
     /**
      * Default values.
@@ -75,7 +76,7 @@ class Regex implements RouteInterface
     /**
      * factory(): defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::factory()
+     * @see    RouteInterface::factory()
      *
      * @param  iterable $options
      * @return Regex
@@ -148,7 +149,7 @@ class Regex implements RouteInterface
     /**
      * assemble(): Defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::assemble()
+     * @see    RouteInterface::assemble()
      *
      * @return mixed
      */
@@ -172,9 +173,9 @@ class Regex implements RouteInterface
     }
 
     /**
-     * getAssembledParams(): defined by RouteInterface interface.
+     * getAssembledParams(): defined by HttpRouteInterface interface.
      *
-     * @see    RouteInterface::getAssembledParams
+     * @see    HttpRouteInterface::getAssembledParams
      *
      * @return array
      */

--- a/src/Http/RouteInterface.php
+++ b/src/Http/RouteInterface.php
@@ -4,18 +4,10 @@ declare(strict_types=1);
 
 namespace Laminas\Router\Http;
 
-use Laminas\Router\RouteInterface as BaseRoute;
-use Laminas\Stdlib\RequestInterface as Request;
-
 /**
- * Tree specific route interface.
- *
- * Note: the additional {@see self::match()} annotation is only here for documentation purposes, because we cannot
- *       change the signature of {@see self::match()} in the interface definition without breaking BC.
- *
- * @method RouteMatch|null match(Request $request, int|null $pathOffset = null, array $options = [])
+ * @deprecated Use HttpRouteInterface instead; this will be removed in v4.0
  */
-interface RouteInterface extends BaseRoute
+interface RouteInterface extends HttpRouteInterface
 {
     /**
      * Get a list of parameters used while assembling.

--- a/src/Http/Scheme.php
+++ b/src/Http/Scheme.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Router\Http;
 
 use Laminas\Router\Exception;
+use Laminas\Router\RouteInterface;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
 use Traversable;
@@ -16,7 +17,7 @@ use function sprintf;
 /**
  * Scheme route.
  */
-class Scheme implements RouteInterface
+class Scheme implements HttpRouteInterface
 {
     /**
      * Default values.
@@ -51,7 +52,7 @@ class Scheme implements RouteInterface
     /**
      * factory(): defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::factory()
+     * @see    RouteInterface::factory()
      *
      * @param  iterable $options
      * @return Scheme
@@ -82,7 +83,7 @@ class Scheme implements RouteInterface
     /**
      * match(): defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::match()
+     * @see    RouteInterface::match()
      *
      * @return RouteMatch|null
      */
@@ -105,7 +106,7 @@ class Scheme implements RouteInterface
     /**
      * assemble(): Defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::assemble()
+     * @see    RouteInterface::assemble()
      *
      * @return mixed
      */
@@ -120,9 +121,9 @@ class Scheme implements RouteInterface
     }
 
     /**
-     * getAssembledParams(): defined by RouteInterface interface.
+     * getAssembledParams(): defined by HttpRouteInterface interface.
      *
-     * @see    RouteInterface::getAssembledParams
+     * @see    HttpRouteInterface::getAssembledParams
      *
      * @return array
      */

--- a/src/Http/Segment.php
+++ b/src/Http/Segment.php
@@ -6,6 +6,7 @@ namespace Laminas\Router\Http;
 
 use Laminas\I18n\Translator\TranslatorInterface as Translator;
 use Laminas\Router\Exception;
+use Laminas\Router\RouteInterface;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
 use Traversable;
@@ -26,7 +27,7 @@ use function strtr;
 /**
  * Segment route.
  */
-class Segment implements RouteInterface
+class Segment implements HttpRouteInterface
 {
     /**
      * Cache for the encode output.
@@ -132,7 +133,7 @@ class Segment implements RouteInterface
     /**
      * factory(): defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::factory()
+     * @see    RouteInterface::factory()
      *
      * @param  iterable $options
      * @return Segment
@@ -364,7 +365,7 @@ class Segment implements RouteInterface
     /**
      * match(): defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::match()
+     * @see    RouteInterface::match()
      *
      * @param  string|null $pathOffset
      * @return RouteMatch|null
@@ -420,7 +421,7 @@ class Segment implements RouteInterface
     /**
      * assemble(): Defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::assemble()
+     * @see    RouteInterface::assemble()
      *
      * @return mixed
      */
@@ -438,9 +439,9 @@ class Segment implements RouteInterface
     }
 
     /**
-     * getAssembledParams(): defined by RouteInterface interface.
+     * getAssembledParams(): defined by HttpRouteInterface interface.
      *
-     * @see    RouteInterface::getAssembledParams
+     * @see    HttpRouteInterface::getAssembledParams
      *
      * @return array
      */

--- a/src/Http/TranslatorAwareTreeRouteStack.php
+++ b/src/Http/TranslatorAwareTreeRouteStack.php
@@ -7,12 +7,13 @@ namespace Laminas\Router\Http;
 use Laminas\I18n\Translator\TranslatorAwareInterface;
 use Laminas\I18n\Translator\TranslatorInterface as Translator;
 use Laminas\Router\Exception;
+use Laminas\Router\RouteInterface;
 use Laminas\Stdlib\RequestInterface as Request;
 
 /**
  * Translator aware tree route stack.
  *
- * @template TRoute of RouteInterface
+ * @template TRoute of HttpRouteInterface
  * @template-extends TreeRouteStack<TRoute>
  */
 class TranslatorAwareTreeRouteStack extends TreeRouteStack implements TranslatorAwareInterface
@@ -39,9 +40,9 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
     protected $translatorTextDomain = 'default';
 
     /**
-     * match(): defined by \Laminas\Router\RouteInterface
+     * match(): defined by RouteInterface
      *
-     * @see    \Laminas\Router\RouteInterface::match()
+     * @see    RouteInterface::match()
      *
      * @param  integer|null $pathOffset
      * @return RouteMatch|null
@@ -60,9 +61,9 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
     }
 
     /**
-     * assemble(): defined by \Laminas\Router\RouteInterface interface.
+     * assemble(): defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::assemble()
+     * @see    RouteInterface::assemble()
      *
      * @return mixed
      * @throws Exception\InvalidArgumentException

--- a/src/Http/TreeRouteStack.php
+++ b/src/Http/TreeRouteStack.php
@@ -6,6 +6,7 @@ namespace Laminas\Router\Http;
 
 use ArrayObject;
 use Laminas\Router\Exception;
+use Laminas\Router\RouteInterface;
 use Laminas\Router\RouteInvokableFactory;
 use Laminas\Router\SimpleRouteStack;
 use Laminas\ServiceManager\Config;
@@ -26,7 +27,7 @@ use function strlen;
 /**
  * Tree search implementation.
  *
- * @template TRoute of RouteInterface
+ * @template TRoute of HttpRouteInterface
  * @template-extends SimpleRouteStack<TRoute>
  */
 class TreeRouteStack extends SimpleRouteStack
@@ -66,7 +67,7 @@ class TreeRouteStack extends SimpleRouteStack
     /**
      * factory(): defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::factory()
+     * @see    RouteInterface::factory()
      *
      * @param  iterable $options
      * @return SimpleRouteStack
@@ -164,7 +165,7 @@ class TreeRouteStack extends SimpleRouteStack
      */
     public function addRoute($name, $route, $priority = null)
     {
-        if (! $route instanceof RouteInterface) {
+        if (! $route instanceof HttpRouteInterface) {
             $route = $this->routeFromArray($route);
         }
 
@@ -216,7 +217,7 @@ class TreeRouteStack extends SimpleRouteStack
             $route = parent::routeFromArray($specs);
         }
 
-        if (! $route instanceof RouteInterface) {
+        if (! $route instanceof HttpRouteInterface) {
             throw new Exception\RuntimeException('Given route does not implement HTTP route interface');
         }
 
@@ -267,7 +268,7 @@ class TreeRouteStack extends SimpleRouteStack
      */
     public function addPrototype($name, $route)
     {
-        if (! $route instanceof RouteInterface) {
+        if (! $route instanceof HttpRouteInterface) {
             $route = $this->routeFromArray($route);
         }
 
@@ -288,9 +289,9 @@ class TreeRouteStack extends SimpleRouteStack
     }
 
     /**
-     * match(): defined by \Laminas\Router\RouteInterface
+     * match(): defined by RouteInterface
      *
-     * @see    \Laminas\Router\RouteInterface::match()
+     * @see    RouteInterface::match()
      *
      * @param  int|null $pathOffset
      * @return RouteMatch|null
@@ -343,9 +344,9 @@ class TreeRouteStack extends SimpleRouteStack
     }
 
     /**
-     * assemble(): defined by \Laminas\Router\RouteInterface interface.
+     * assemble(): defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::assemble()
+     * @see    RouteInterface::assemble()
      *
      * @return mixed
      * @throws Exception\InvalidArgumentException

--- a/src/Http/Wildcard.php
+++ b/src/Http/Wildcard.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Router\Http;
 
 use Laminas\Router\Exception;
+use Laminas\Router\RouteInterface;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
 use Traversable;
@@ -31,7 +32,7 @@ use function substr;
  * Misuse of this route type can lead to potential security issues.
  * Use the `Segment` route type instead.
  */
-class Wildcard implements RouteInterface
+class Wildcard implements HttpRouteInterface
 {
     /**
      * Default values.
@@ -70,7 +71,7 @@ class Wildcard implements RouteInterface
     /**
      * factory(): defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::factory()
+     * @see    RouteInterface::factory()
      *
      * @param  iterable $options
      * @return Wildcard
@@ -105,7 +106,7 @@ class Wildcard implements RouteInterface
     /**
      * match(): defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::match()
+     * @see    RouteInterface::match()
      *
      * @param  integer|null $pathOffset
      * @return RouteMatch|null
@@ -160,7 +161,7 @@ class Wildcard implements RouteInterface
     /**
      * assemble(): Defined by RouteInterface interface.
      *
-     * @see    \Laminas\Router\RouteInterface::assemble()
+     * @see    RouteInterface::assemble()
      *
      * @return mixed
      */
@@ -189,9 +190,9 @@ class Wildcard implements RouteInterface
     }
 
     /**
-     * getAssembledParams(): defined by RouteInterface interface.
+     * getAssembledParams(): defined by HttpRouteInterface interface.
      *
-     * @see    RouteInterface::getAssembledParams
+     * @see    HttpRouteInterface::getAssembledParams
      *
      * @return array
      */

--- a/test/Http/ChainTest.php
+++ b/test/Http/ChainTest.php
@@ -6,7 +6,7 @@ namespace LaminasTest\Router\Http;
 
 use Laminas\Http\Request;
 use Laminas\Router\Http\Chain;
-use Laminas\Router\Http\RouteInterface;
+use Laminas\Router\Http\HttpRouteInterface;
 use Laminas\Router\Http\RouteMatch;
 use Laminas\Router\Http\Segment;
 use Laminas\Router\Http\Wildcard;
@@ -23,7 +23,7 @@ final class ChainTest extends TestCase
 {
     public static function getRoute(): Chain
     {
-        /** @var RoutePluginManager<RouteInterface> $routePlugins */
+        /** @var RoutePluginManager<HttpRouteInterface> $routePlugins */
         $routePlugins = new RoutePluginManager(new ServiceManager());
 
         return new Chain(
@@ -56,7 +56,7 @@ final class ChainTest extends TestCase
 
     public static function getRouteWithOptionalParam(): Chain
     {
-        /** @var RoutePluginManager<RouteInterface> $routePlugins */
+        /** @var RoutePluginManager<HttpRouteInterface> $routePlugins */
         $routePlugins = new RoutePluginManager(new ServiceManager());
 
         return new Chain(

--- a/test/Http/PartTest.php
+++ b/test/Http/PartTest.php
@@ -8,9 +8,9 @@ use ArrayObject;
 use Laminas\Http\Request;
 use Laminas\Router\Exception\InvalidArgumentException;
 use Laminas\Router\Exception\RuntimeException;
+use Laminas\Router\Http\HttpRouteInterface;
 use Laminas\Router\Http\Literal;
 use Laminas\Router\Http\Part;
-use Laminas\Router\Http\RouteInterface;
 use Laminas\Router\Http\RouteMatch;
 use Laminas\Router\Http\Segment;
 use Laminas\Router\Http\Wildcard;
@@ -29,7 +29,7 @@ use function strpos;
 
 final class PartTest extends TestCase
 {
-    /** @return RoutePluginManager<RouteInterface> */
+    /** @return RoutePluginManager<HttpRouteInterface> */
     public static function getRoutePlugins(): RoutePluginManager
     {
         return new RoutePluginManager(new ServiceManager(), [

--- a/test/Http/TestAsset/DummyRoute.php
+++ b/test/Http/TestAsset/DummyRoute.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace LaminasTest\Router\Http\TestAsset;
 
-use Laminas\Router\Http\RouteInterface;
+use Laminas\Router\Http\HttpRouteInterface;
 use Laminas\Router\Http\RouteMatch;
 use Laminas\Stdlib\RequestInterface;
 
 /**
  * Dummy route.
  */
-class DummyRoute implements RouteInterface
+class DummyRoute implements HttpRouteInterface
 {
     /**
      * match(): defined by RouteInterface interface.

--- a/test/Http/TranslatorAwareTreeRouteStackTest.php
+++ b/test/Http/TranslatorAwareTreeRouteStackTest.php
@@ -7,7 +7,7 @@ namespace LaminasTest\Router\Http;
 use Laminas\Http\Request;
 use Laminas\I18n\Translator\Translator;
 use Laminas\I18n\Translator\TranslatorAwareInterface;
-use Laminas\Router\Http\RouteInterface;
+use Laminas\Router\Http\HttpRouteInterface;
 use Laminas\Router\Http\TranslatorAwareTreeRouteStack;
 use Laminas\Uri\Http as HttpUri;
 use PHPUnit\Framework\TestCase;
@@ -89,7 +89,7 @@ final class TranslatorAwareTreeRouteStackTest extends TestCase
         $translator = new Translator();
         $request    = new Request();
 
-        $route = $this->createMock(RouteInterface::class);
+        $route = $this->createMock(HttpRouteInterface::class);
         $route->expects($this->once())
               ->method('match')
             ->with(
@@ -109,7 +109,7 @@ final class TranslatorAwareTreeRouteStackTest extends TestCase
         $translator = new Translator();
         $uri        = new HttpUri();
 
-        $route = $this->createMock(RouteInterface::class);
+        $route = $this->createMock(HttpRouteInterface::class);
         $route->expects($this->once())
               ->method('assemble')
             ->with(


### PR DESCRIPTION
- Add `Laminas\Router\Http\HttpRouteInterface` extending `Laminas\Router\RouteInterface`.
- Deprecate `Laminas\Router\Http\RouteInterface` and update it to extend `HttpRouteInterface`.
- Update HTTP route implementations to implement `HttpRouteInterface`.
- Update `TreeRouteStack` and `Chain` to use `HttpRouteInterface` for templates and type checks.
- Update tests and Psalm baseline.