### PR TITLE
Enable backward compatibility check

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,5 +1,6 @@
 {
     "ignore_php_platform_requirements": {
         "8.5": true
-    }
+    },
+    "backwardCompatibilityCheck": true
 }


### PR DESCRIPTION
This enables the `backwardCompatibilityCheck` option in `.laminas-ci.json` to ensure backward compatibility is maintained in future changes.

