### PR TITLE
[Remove deprecated feature] Remove ServiceManager v2 compatibility

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -622,28 +622,6 @@
       <code><![CDATA[Module]]></code>
     </UnusedClass>
   </file>
-  <file src="src/RouteInvokableFactory.php">
-    <DeprecatedInterface>
-      <code><![CDATA[RouteInvokableFactory]]></code>
-      <code><![CDATA[RouteInvokableFactory]]></code>
-    </DeprecatedInterface>
-    <MissingReturnType>
-      <code><![CDATA[setCreationOptions]]></code>
-    </MissingReturnType>
-    <ParamNameMismatch>
-      <code><![CDATA[$container]]></code>
-      <code><![CDATA[$container]]></code>
-      <code><![CDATA[$container]]></code>
-      <code><![CDATA[$normalizedName]]></code>
-      <code><![CDATA[$normalizedName]]></code>
-      <code><![CDATA[$routeName]]></code>
-      <code><![CDATA[$routeName]]></code>
-      <code><![CDATA[$routeName]]></code>
-    </ParamNameMismatch>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[setCreationOptions]]></code>
-    </PossiblyUnusedMethod>
-  </file>
   <file src="src/RouteMatch.php">
     <PropertyNotSetInConstructor>
       <code><![CDATA[$matchedRouteName]]></code>
@@ -674,11 +652,6 @@
       <code><![CDATA[$shareByDefault]]></code>
     </PossiblyUnusedProperty>
   </file>
-  <file src="src/RoutePluginManagerFactory.php">
-    <DeprecatedInterface>
-      <code><![CDATA[RoutePluginManagerFactory]]></code>
-    </DeprecatedInterface>
-  </file>
   <file src="src/RouteStackInterface.php">
     <PossiblyUnusedReturnValue>
       <code><![CDATA[static]]></code>
@@ -695,15 +668,9 @@
     </MixedAssignment>
   </file>
   <file src="src/RouterFactory.php">
-    <DeprecatedInterface>
-      <code><![CDATA[RouterFactory]]></code>
-    </DeprecatedInterface>
     <MixedReturnStatement>
       <code><![CDATA[$container->get('HttpRouter')]]></code>
     </MixedReturnStatement>
-    <ParamNameMismatch>
-      <code><![CDATA[$container]]></code>
-    </ParamNameMismatch>
   </file>
   <file src="src/SimpleRouteStack.php">
     <DocblockTypeContradiction>
@@ -1235,9 +1202,6 @@
     </MissingReturnType>
   </file>
   <file src="test/RoutePluginManagerFactoryTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[createService]]></code>
-    </DeprecatedMethod>
     <MissingClosureParamType>
       <code><![CDATA[$container]]></code>
     </MissingClosureParamType>
@@ -1245,7 +1209,6 @@
       <code><![CDATA[fn($container) => $this->createMock(RouteInterface::class)]]></code>
     </MissingClosureReturnType>
     <MissingReturnType>
-      <code><![CDATA[testCreateServiceReturnsAPluginManager]]></code>
       <code><![CDATA[testInvocationCanProvideOptionsToThePluginManager]]></code>
       <code><![CDATA[testInvocationReturnsAPluginManager]]></code>
     </MissingReturnType>

--- a/src/RouteInvokableFactory.php
+++ b/src/RouteInvokableFactory.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace Laminas\Router;
 
-use Laminas\ServiceManager\AbstractFactoryInterface;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
 use Psr\Container\ContainerInterface;
 
 use function class_exists;
@@ -21,51 +19,27 @@ use function sprintf;
  * abstract factory to map FQCN services to invokables.
  */
 class RouteInvokableFactory implements
-    AbstractFactoryInterface,
-    FactoryInterface
+    AbstractFactoryInterface
 {
-    /**
-     * Options used to create instance (used with laminas-servicemanager v2)
-     *
-     * @var array
-     */
-    protected $creationOptions = [];
-
     /**
      * Can we create a route instance with the given name? (v3)
      *
      * Only works for FQCN $routeName values, for classes that implement RouteInterface.
      *
-     * @param string $routeName
+     * @param string $requestedName
      * @return bool
      */
-    public function canCreate(ContainerInterface $container, $routeName)
+    public function canCreate(ContainerInterface $container, $requestedName)
     {
-        if (! class_exists($routeName)) {
+        if (! class_exists($requestedName)) {
             return false;
         }
 
-        if (! is_subclass_of($routeName, RouteInterface::class)) {
+        if (! is_subclass_of($requestedName, RouteInterface::class)) {
             return false;
         }
 
         return true;
-    }
-
-    /**
-     * Can we create a route instance with the given name? (v2)
-     *
-     * Proxies to canCreate().
-     *
-     * @deprecated Since 3.6.0 - This component is no longer compatible with Service Manager v2
-     *
-     * @param string $normalizedName
-     * @param string $routeName
-     * @return bool
-     */
-    public function canCreateServiceWithName(ServiceLocatorInterface $container, $normalizedName, $routeName)
-    {
-        return $this->canCreate($container, $routeName);
     }
 
     /**
@@ -77,74 +51,31 @@ class RouteInvokableFactory implements
      * Otherwise, it uses the class' `factory()` method with the provided
      * $options to produce an instance.
      *
-     * @param string $routeName
+     * @param string $requestedName
      * @param null|array $options
      * @return RouteInterface
      */
-    public function __invoke(ContainerInterface $container, $routeName, ?array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         $options ??= [];
 
-        if (! class_exists($routeName)) {
+        if (! class_exists($requestedName)) {
             throw new ServiceNotCreatedException(sprintf(
                 '%s: failed retrieving invokable class "%s"; class does not exist',
                 self::class,
-                $routeName
+                $requestedName
             ));
         }
 
-        if (! is_subclass_of($routeName, RouteInterface::class)) {
+        if (! is_subclass_of($requestedName, RouteInterface::class)) {
             throw new ServiceNotCreatedException(sprintf(
                 '%s: failed retrieving invokable class "%s"; class does not implement %s',
                 self::class,
-                $routeName,
+                $requestedName,
                 RouteInterface::class
             ));
         }
 
-        return $routeName::factory($options);
-    }
-
-    /**
-     * Create a route instance with the given name. (v2)
-     *
-     * Proxies to __invoke().
-     *
-     * @deprecated Since 3.6.0 - This component is no longer compatible with Service Manager v2
-     *
-     * @param string $normalizedName
-     * @param string $routeName
-     * @return RouteInterface
-     */
-    public function createServiceWithName(ServiceLocatorInterface $container, $normalizedName, $routeName)
-    {
-        return $this($container, $routeName, $this->creationOptions);
-    }
-
-    /**
-     * Create and return RouteInterface instance
-     *
-     * For use with laminas-servicemanager v2; proxies to __invoke().
-     *
-     * @deprecated Since 3.6.0 - This component is no longer compatible with Service Manager v2
-     *
-     * @param null|string $normalizedName Not used
-     * @param null|string $routeName
-     * @return RouteInterface
-     */
-    public function createService(ServiceLocatorInterface $container, $normalizedName = null, $routeName = null)
-    {
-        $routeName ??= RouteInterface::class;
-        return $this($container, $routeName, $this->creationOptions);
-    }
-
-    /**
-     * Set options to use when creating a service (v2)
-     *
-     * @deprecated Since 3.6.0 - This component is no longer compatible with Service Manager v2
-     */
-    public function setCreationOptions(array $creationOptions)
-    {
-        $this->creationOptions = $creationOptions;
+        return $requestedName::factory($options);
     }
 }

--- a/src/RoutePluginManagerFactory.php
+++ b/src/RoutePluginManagerFactory.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Router;
 
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerInterface;
 
 class RoutePluginManagerFactory implements FactoryInterface
@@ -13,27 +12,13 @@ class RoutePluginManagerFactory implements FactoryInterface
     /**
      * Create and return a route plugin manager.
      *
-     * @param  string $name
+     * @param  string $requestedName
      * @param  null|array $options
      * @return RoutePluginManager
      */
-    public function __invoke(ContainerInterface $container, $name, ?array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         $options ??= [];
         return new RoutePluginManager($container, $options);
-    }
-
-    /**
-     * Create and return RoutePluginManager instance.
-     *
-     * For use with laminas-servicemanager v2; proxies to __invoke().
-     *
-     * @deprecated Since 3.6.0 - This component is no longer compatible with Service Manager v2
-     *
-     * @return RoutePluginManager
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator)
-    {
-        return $this($serviceLocator, RoutePluginManager::class);
     }
 }

--- a/src/RouterFactory.php
+++ b/src/RouterFactory.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Router;
 
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerInterface;
 
 class RouterFactory implements FactoryInterface
@@ -22,22 +21,5 @@ class RouterFactory implements FactoryInterface
     public function __invoke(ContainerInterface $container, $name, ?array $options = null)
     {
         return $container->get('HttpRouter');
-    }
-
-    /**
-     * Create and return RouteStackInterface instance
-     *
-     * For use with laminas-servicemanager v2; proxies to __invoke().
-     *
-     * @deprecated Since 3.6.0 - This component is no longer compatible with Service Manager v2
-     *
-     * @param null|string $normalizedName
-     * @param null|string $requestedName
-     * @return RouteStackInterface
-     */
-    public function createService(ServiceLocatorInterface $container, $normalizedName = null, $requestedName = null)
-    {
-        $requestedName ??= 'Router';
-        return $this($container, $requestedName);
     }
 }

--- a/test/RoutePluginManagerFactoryTest.php
+++ b/test/RoutePluginManagerFactoryTest.php
@@ -7,7 +7,6 @@ namespace LaminasTest\Router;
 use Laminas\Router\RouteInterface;
 use Laminas\Router\RoutePluginManager;
 use Laminas\Router\RoutePluginManagerFactory;
-use Laminas\ServiceManager\ServiceLocatorInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -27,14 +26,6 @@ final class RoutePluginManagerFactoryTest extends TestCase
     public function testInvocationReturnsAPluginManager()
     {
         $plugins = $this->factory->__invoke($this->container, RoutePluginManager::class);
-        $this->assertInstanceOf(RoutePluginManager::class, $plugins);
-    }
-
-    public function testCreateServiceReturnsAPluginManager()
-    {
-        $container = $this->createMock(ServiceLocatorInterface::class);
-
-        $plugins = $this->factory->createService($container);
         $this->assertInstanceOf(RoutePluginManager::class, $plugins);
     }
 


### PR DESCRIPTION
- Remove `createService`, `createServiceWithName`, `canCreateServiceWithName`, and `setCreationOptions` methods across factories.
- Update `FactoryInterface` imports to use `Laminas\ServiceManager\Factory\FactoryInterface`.
- Rename `$name` and `$routeName` parameters to `$requestedName` to comply with ServiceManager v3 interfaces.
- Remove `RouteInvokableFactory` implementation of `FactoryInterface` in favor of `AbstractFactoryInterface`.
- Remove tests for deprecated v2 methods.
- Update Psalm baseline.