### PR TITLE
Add `void` return types to test methods

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -775,11 +775,6 @@
     <DeprecatedClass>
       <code><![CDATA[Wildcard::class]]></code>
     </DeprecatedClass>
-    <MissingReturnType>
-      <code><![CDATA[testAssembling]]></code>
-      <code><![CDATA[testFactory]]></code>
-      <code><![CDATA[testMatching]]></code>
-    </MissingReturnType>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$key]]></code>
     </MixedArgumentTypeCoercion>
@@ -792,15 +787,6 @@
     <DuplicateArrayKey>
       <code><![CDATA['foo' => 'bat']]></code>
     </DuplicateArrayKey>
-    <MissingReturnType>
-      <code><![CDATA[testAssembling]]></code>
-      <code><![CDATA[testAssemblingWithMissingParameter]]></code>
-      <code><![CDATA[testFactory]]></code>
-      <code><![CDATA[testFailedHostnameSegmentMatchDoesNotEmitErrors]]></code>
-      <code><![CDATA[testGetAssembledParams]]></code>
-      <code><![CDATA[testMatching]]></code>
-      <code><![CDATA[testNoMatchWithoutUriMethod]]></code>
-    </MissingReturnType>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$key]]></code>
     </MixedArgumentTypeCoercion>
@@ -813,32 +799,14 @@
     <MissingClosureParamType>
       <code><![CDATA[$services]]></code>
     </MissingClosureParamType>
-    <MissingClosureReturnType>
-      <code><![CDATA[static fn($services) => new RoutePluginManager($services)]]></code>
-    </MissingClosureReturnType>
     <MixedArgument>
       <code><![CDATA[$services]]></code>
     </MixedArgument>
   </file>
   <file src="test/Http/LiteralTest.php">
-    <MissingReturnType>
-      <code><![CDATA[testAssembling]]></code>
-      <code><![CDATA[testEmptyLiteral]]></code>
-      <code><![CDATA[testFactory]]></code>
-      <code><![CDATA[testGetAssembledParams]]></code>
-      <code><![CDATA[testMatching]]></code>
-      <code><![CDATA[testNoMatchWithoutUriMethod]]></code>
-    </MissingReturnType>
     <MixedAssignment>
       <code><![CDATA[$result]]></code>
     </MixedAssignment>
-  </file>
-  <file src="test/Http/MethodTest.php">
-    <MissingReturnType>
-      <code><![CDATA[testFactory]]></code>
-      <code><![CDATA[testMatching]]></code>
-      <code><![CDATA[testNoMatchWithoutVerb]]></code>
-    </MissingReturnType>
   </file>
   <file src="test/Http/PartTest.php">
     <ArgumentTypeCoercion>
@@ -893,59 +861,18 @@
             ],
         ])]]></code>
     </LessSpecificReturnStatement>
-    <MissingReturnType>
-      <code><![CDATA[testAssembleNonTerminatedRoute]]></code>
-      <code><![CDATA[testAssembling]]></code>
-      <code><![CDATA[testBaseRouteMayNotBePartRoute]]></code>
-      <code><![CDATA[testFactory]]></code>
-      <code><![CDATA[testFactoryShouldAcceptTraversableChildRoutes]]></code>
-      <code><![CDATA[testGetAssembledParams]]></code>
-      <code><![CDATA[testMatching]]></code>
-      <code><![CDATA[testNoMatchWithoutUriMethod]]></code>
-      <code><![CDATA[testPartRouteMarkedAsMayTerminateButWithQueryRouteChildWillMatchChildRoute]]></code>
-      <code><![CDATA[testPartRouteMarkedAsMayTerminateCanMatchWhenQueryStringPresent]]></code>
-    </MissingReturnType>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$key]]></code>
     </MixedArgumentTypeCoercion>
     <MixedAssignment>
-      <code><![CDATA[$query]]></code>
-      <code><![CDATA[$query]]></code>
       <code><![CDATA[$result]]></code>
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
     <MoreSpecificReturnType>
       <code><![CDATA[RoutePluginManager<HttpRouteInterface>]]></code>
     </MoreSpecificReturnType>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[testAssembling]]></code>
-      <code><![CDATA[testMatching]]></code>
-    </PossiblyInvalidArgument>
-    <UnusedVariable>
-      <code><![CDATA[$query]]></code>
-      <code><![CDATA[$query]]></code>
-      <code><![CDATA[$route]]></code>
-    </UnusedVariable>
-  </file>
-  <file src="test/Http/PlaceholderTest.php">
-    <MissingReturnType>
-      <code><![CDATA[testAssembling]]></code>
-      <code><![CDATA[testFactory]]></code>
-      <code><![CDATA[testGetAssembledParams]]></code>
-      <code><![CDATA[testMatch]]></code>
-      <code><![CDATA[testPlaceholderDefault]]></code>
-    </MissingReturnType>
   </file>
   <file src="test/Http/RegexTest.php">
-    <MissingReturnType>
-      <code><![CDATA[testAssembling]]></code>
-      <code><![CDATA[testEncodedDecode]]></code>
-      <code><![CDATA[testFactory]]></code>
-      <code><![CDATA[testGetAssembledParams]]></code>
-      <code><![CDATA[testMatching]]></code>
-      <code><![CDATA[testNoMatchWithoutUriMethod]]></code>
-      <code><![CDATA[testRawDecode]]></code>
-    </MissingReturnType>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$key]]></code>
     </MixedArgumentTypeCoercion>
@@ -958,25 +885,7 @@
       <code><![CDATA[getParam]]></code>
     </PossiblyNullReference>
   </file>
-  <file src="test/Http/RouteMatchTest.php">
-    <MissingReturnType>
-      <code><![CDATA[testLengthIsMerged]]></code>
-      <code><![CDATA[testLengthIsStored]]></code>
-      <code><![CDATA[testMatchedRouteNameIsOverriddenOnMerge]]></code>
-      <code><![CDATA[testMatchedRouteNameIsPrependedWhenAlreadySet]]></code>
-      <code><![CDATA[testMatchedRouteNameIsSet]]></code>
-      <code><![CDATA[testParamsAreStored]]></code>
-    </MissingReturnType>
-  </file>
   <file src="test/Http/SchemeTest.php">
-    <MissingReturnType>
-      <code><![CDATA[testAssembling]]></code>
-      <code><![CDATA[testFactory]]></code>
-      <code><![CDATA[testGetAssembledParams]]></code>
-      <code><![CDATA[testMatching]]></code>
-      <code><![CDATA[testNoMatchWithoutUriMethod]]></code>
-      <code><![CDATA[testNoMatchingOnDifferentScheme]]></code>
-    </MissingReturnType>
     <MixedAssignment>
       <code><![CDATA[$path]]></code>
     </MixedAssignment>
@@ -989,20 +898,6 @@
       <code><![CDATA[$offset]]></code>
       <code><![CDATA[$offset]]></code>
     </InvalidArgument>
-    <MissingReturnType>
-      <code><![CDATA[assemblingWithL10n]]></code>
-      <code><![CDATA[matchingWithL10n]]></code>
-      <code><![CDATA[testAssemblingWithExistingChild]]></code>
-      <code><![CDATA[testAssemblingWithMissingParameterInRoot]]></code>
-      <code><![CDATA[testEncodeCache]]></code>
-      <code><![CDATA[testEncodedDecode]]></code>
-      <code><![CDATA[testFactory]]></code>
-      <code><![CDATA[testNoMatchWithoutUriMethod]]></code>
-      <code><![CDATA[testParseExceptions]]></code>
-      <code><![CDATA[testRawDecode]]></code>
-      <code><![CDATA[testTranslatedAssemblingThrowsExceptionWithoutTranslator]]></code>
-      <code><![CDATA[testTranslatedMatchingThrowsExceptionWithoutTranslator]]></code>
-    </MissingReturnType>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$key]]></code>
       <code><![CDATA[$key]]></code>
@@ -1030,41 +925,6 @@
     </UnsafeInstantiation>
   </file>
   <file src="test/Http/TreeRouteStackTest.php">
-    <MissingReturnType>
-      <code><![CDATA[testAddRouteAcceptsTraversable]]></code>
-      <code><![CDATA[testAddRouteRequiresHttpSpecificRoute]]></code>
-      <code><![CDATA[testAddRouteViaStringRequiresHttpSpecificRoute]]></code>
-      <code><![CDATA[testAssemble]]></code>
-      <code><![CDATA[testAssembleCanonicalUriWithGivenUri]]></code>
-      <code><![CDATA[testAssembleCanonicalUriWithHostnameRoute]]></code>
-      <code><![CDATA[testAssembleCanonicalUriWithHostnameRouteAndRequestUriWithoutScheme]]></code>
-      <code><![CDATA[testAssembleCanonicalUriWithHostnameRouteWithoutScheme]]></code>
-      <code><![CDATA[testAssembleCanonicalUriWithRequestUri]]></code>
-      <code><![CDATA[testAssembleCanonicalUriWithoutRequestUri]]></code>
-      <code><![CDATA[testAssembleNonExistentChildRoute]]></code>
-      <code><![CDATA[testAssembleNonExistentRoute]]></code>
-      <code><![CDATA[testAssembleWithEncodedPath]]></code>
-      <code><![CDATA[testAssembleWithEncodedPathAndQueryParams]]></code>
-      <code><![CDATA[testAssembleWithFragment]]></code>
-      <code><![CDATA[testAssembleWithQueryParams]]></code>
-      <code><![CDATA[testAssembleWithScheme]]></code>
-      <code><![CDATA[testAssembleWithoutNameOption]]></code>
-      <code><![CDATA[testBaseUrlLengthIsPassedAsOffset]]></code>
-      <code><![CDATA[testChainRouteAssembling]]></code>
-      <code><![CDATA[testChainRouteAssemblingWithChildrenAndSecureScheme]]></code>
-      <code><![CDATA[testDefaultParamDoesNotOverrideParam]]></code>
-      <code><![CDATA[testDefaultParamDoesNotOverrideParamForAssembling]]></code>
-      <code><![CDATA[testDefaultParamIsAddedToMatch]]></code>
-      <code><![CDATA[testDefaultParamIsUsedForAssembling]]></code>
-      <code><![CDATA[testFactory]]></code>
-      <code><![CDATA[testNoMatchWithoutUriMethod]]></code>
-      <code><![CDATA[testNoOffsetIsPassedWithoutBaseUrl]]></code>
-      <code><![CDATA[testPriorityIsPassedToPartRoute]]></code>
-      <code><![CDATA[testPrototypeRoute]]></code>
-      <code><![CDATA[testSetBaseUrl]]></code>
-      <code><![CDATA[testSetBaseUrlFromFirstMatch]]></code>
-      <code><![CDATA[testSetRequestUri]]></code>
-    </MissingReturnType>
     <MixedAssignment>
       <code><![CDATA[$routes]]></code>
     </MixedAssignment>
@@ -1080,9 +940,6 @@
       <code><![CDATA[getParam]]></code>
       <code><![CDATA[getParam]]></code>
     </PossiblyNullReference>
-    <UnusedMethodCall>
-      <code><![CDATA[setAccessible]]></code>
-    </UnusedMethodCall>
   </file>
   <file src="test/Http/WildcardTest.php">
     <DeprecatedClass>
@@ -1229,16 +1086,6 @@
       <code><![CDATA[null]]></code>
     </NullArgument>
   </file>
-  <file src="test/RouteMatchTest.php">
-    <MissingReturnType>
-      <code><![CDATA[testGetNonExistentParamWithDefault]]></code>
-      <code><![CDATA[testGetNonExistentParamWithoutDefault]]></code>
-      <code><![CDATA[testGetParam]]></code>
-      <code><![CDATA[testMatchedRouteNameIsSet]]></code>
-      <code><![CDATA[testParamsAreStored]]></code>
-      <code><![CDATA[testSetParam]]></code>
-    </MissingReturnType>
-  </file>
   <file src="test/RoutePluginManagerFactoryTest.php">
     <DeprecatedMethod>
       <code><![CDATA[createService]]></code>
@@ -1246,14 +1093,6 @@
     <MissingClosureParamType>
       <code><![CDATA[$container]]></code>
     </MissingClosureParamType>
-    <MissingClosureReturnType>
-      <code><![CDATA[fn($container) => $this->createMock(RouteInterface::class)]]></code>
-    </MissingClosureReturnType>
-    <MissingReturnType>
-      <code><![CDATA[testCreateServiceReturnsAPluginManager]]></code>
-      <code><![CDATA[testInvocationCanProvideOptionsToThePluginManager]]></code>
-      <code><![CDATA[testInvocationReturnsAPluginManager]]></code>
-    </MissingReturnType>
     <PossiblyInvalidArgument>
       <code><![CDATA[$this->container]]></code>
       <code><![CDATA[$this->container]]></code>
@@ -1261,12 +1100,6 @@
     <UnusedClosureParam>
       <code><![CDATA[$container]]></code>
     </UnusedClosureParam>
-  </file>
-  <file src="test/RoutePluginManagerTest.php">
-    <MissingReturnType>
-      <code><![CDATA[testCanLoadAnyRoute]]></code>
-      <code><![CDATA[testLoadNonExistentRoute]]></code>
-    </MissingReturnType>
   </file>
   <file src="test/RouterFactoryTest.php">
     <DeprecatedClass>
@@ -1292,9 +1125,6 @@
     <MissingClosureParamType>
       <code><![CDATA[$services]]></code>
     </MissingClosureParamType>
-    <MissingClosureReturnType>
-      <code><![CDATA[static fn($services) => new RoutePluginManager($services)]]></code>
-    </MissingClosureReturnType>
     <MixedArgument>
       <code><![CDATA[$services]]></code>
     </MixedArgument>
@@ -1310,34 +1140,6 @@
       <code><![CDATA['foo']]></code>
       <code><![CDATA['foo']]></code>
     </InvalidArgument>
-    <MissingReturnType>
-      <code><![CDATA[testAddRouteAsArrayWithOptions]]></code>
-      <code><![CDATA[testAddRouteAsArrayWithPriority]]></code>
-      <code><![CDATA[testAddRouteAsArrayWithoutOptions]]></code>
-      <code><![CDATA[testAddRouteAsArrayWithoutType]]></code>
-      <code><![CDATA[testAddRouteAsTraversable]]></code>
-      <code><![CDATA[testAddRouteWithInvalidArgument]]></code>
-      <code><![CDATA[testAddRouteWithPriority]]></code>
-      <code><![CDATA[testAddRoutesAsArray]]></code>
-      <code><![CDATA[testAddRoutesAsTraversable]]></code>
-      <code><![CDATA[testAddRoutesWithInvalidArgument]]></code>
-      <code><![CDATA[testAssemble]]></code>
-      <code><![CDATA[testAssembleNonExistentRoute]]></code>
-      <code><![CDATA[testAssembleWithoutNameOption]]></code>
-      <code><![CDATA[testDefaultParamDoesNotOverrideParam]]></code>
-      <code><![CDATA[testDefaultParamDoesNotOverrideParamForAssembling]]></code>
-      <code><![CDATA[testDefaultParamIsAddedToMatch]]></code>
-      <code><![CDATA[testDefaultParamIsUsedForAssembling]]></code>
-      <code><![CDATA[testFactory]]></code>
-      <code><![CDATA[testGetRouteByName]]></code>
-      <code><![CDATA[testGetRoutes]]></code>
-      <code><![CDATA[testHasRoute]]></code>
-      <code><![CDATA[testSetRoutePluginManager]]></code>
-      <code><![CDATA[testSetRoutesAsArray]]></code>
-      <code><![CDATA[testSetRoutesAsTraversable]]></code>
-      <code><![CDATA[testSetRoutesWithInvalidArgument]]></code>
-      <code><![CDATA[testremoveRouteAsArray]]></code>
-    </MissingReturnType>
     <NoInterfaceProperties>
       <code><![CDATA[$route->priority]]></code>
     </NoInterfaceProperties>
@@ -1355,16 +1157,5 @@
     <UnsafeInstantiation>
       <code><![CDATA[new static()]]></code>
     </UnsafeInstantiation>
-  </file>
-  <file src="test/TestAsset/Router.php">
-    <ImplementedReturnTypeMismatch>
-      <code><![CDATA[RouteMatch|null]]></code>
-    </ImplementedReturnTypeMismatch>
-    <InvalidReturnType>
-      <code><![CDATA[mixed]]></code>
-    </InvalidReturnType>
-    <UndefinedDocblockClass>
-      <code><![CDATA[RouteMatch|null]]></code>
-    </UndefinedDocblockClass>
   </file>
 </files>

--- a/test/FactoryTester.php
+++ b/test/FactoryTester.php
@@ -32,11 +32,8 @@ final class FactoryTester
 
     /**
      * Test a factory.
-     *
-     * @param  string $classname
-     * @return void
      */
-    public function testFactory($classname, array $requiredOptions, array $options)
+    public function testFactory(string $classname, array $requiredOptions, array $options): void
     {
         $factory = sprintf('%s::factory', $classname);
 

--- a/test/Http/ChainTest.php
+++ b/test/Http/ChainTest.php
@@ -143,12 +143,8 @@ final class ChainTest extends TestCase
         ];
     }
 
-    /**
-     * @param        string   $path
-     * @param        int|null $offset
-     */
     #[DataProvider('routeProvider')]
-    public function testMatching(Chain $route, $path, $offset, ?array $params = null)
+    public function testMatching(Chain $route, string $path, int|null $offset, ?array $params = null): void
     {
         $request = new Request();
         $request->setUri('http://example.com' . $path);
@@ -169,12 +165,8 @@ final class ChainTest extends TestCase
         }
     }
 
-    /**
-     * @param        string   $path
-     * @param        int|null $offset
-     */
     #[DataProvider('routeProvider')]
-    public function testAssembling(Chain $route, $path, $offset, ?array $params = null)
+    public function testAssembling(Chain $route, string $path, int|null $offset, ?array $params = null): void
     {
         if ($params === null) {
             // Data which will not match are not tested for assembling.
@@ -190,7 +182,7 @@ final class ChainTest extends TestCase
         }
     }
 
-    public function testFactory()
+    public function testFactory(): void
     {
         $tester = new FactoryTester($this);
         $tester->testFactory(

--- a/test/Http/HostnameTest.php
+++ b/test/Http/HostnameTest.php
@@ -166,10 +166,10 @@ final class HostnameTest extends TestCase
     }
 
     /**
-     * @param        string   $hostname
+     * @param string   $hostname
      */
     #[DataProvider('routeProvider')]
-    public function testMatching(Hostname $route, $hostname, ?array $params = null)
+    public function testMatching(Hostname $route, $hostname, ?array $params = null): void
     {
         $request = new Request();
         $request->setUri('http://' . $hostname . '/');
@@ -186,11 +186,8 @@ final class HostnameTest extends TestCase
         }
     }
 
-    /**
-     * @param        string   $hostname
-     */
     #[DataProvider('routeProvider')]
-    public function testAssembling(Hostname $route, $hostname, ?array $params = null)
+    public function testAssembling(Hostname $route, string $hostname, ?array $params = null): void
     {
         if ($params === null) {
             // Data which will not match are not tested for assembling.
@@ -205,7 +202,7 @@ final class HostnameTest extends TestCase
         $this->assertEquals($hostname, $uri->getHost());
     }
 
-    public function testNoMatchWithoutUriMethod()
+    public function testNoMatchWithoutUriMethod(): void
     {
         $route   = new Hostname('example.com');
         $request = new BaseRequest();
@@ -242,7 +239,7 @@ final class HostnameTest extends TestCase
         self::assertArrayNotHasKey('domain', $match->getParams());
     }
 
-    public function testAssemblingWithMissingParameter()
+    public function testAssemblingWithMissingParameter(): void
     {
         $route = new Hostname(':foo.example.com');
         $uri   = new HttpUri();
@@ -252,7 +249,7 @@ final class HostnameTest extends TestCase
         $route->assemble([], ['uri' => $uri]);
     }
 
-    public function testGetAssembledParams()
+    public function testGetAssembledParams(): void
     {
         $route = new Hostname(':foo.example.com');
         $uri   = new HttpUri();
@@ -261,7 +258,7 @@ final class HostnameTest extends TestCase
         $this->assertEquals(['foo'], $route->getAssembledParams());
     }
 
-    public function testFactory()
+    public function testFactory(): void
     {
         $tester = new FactoryTester($this);
         $tester->testFactory(
@@ -276,7 +273,7 @@ final class HostnameTest extends TestCase
     }
 
     #[Group('laminas5656')]
-    public function testFailedHostnameSegmentMatchDoesNotEmitErrors()
+    public function testFailedHostnameSegmentMatchDoesNotEmitErrors(): void
     {
         $this->expectException(RuntimeException::class);
         new Hostname(':subdomain.with_underscore.com');

--- a/test/Http/HttpRouterFactoryTest.php
+++ b/test/Http/HttpRouterFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LaminasTest\Router\Http;
 
 use Laminas\Router\Http\HttpRouterFactory;
+use Laminas\Router\RouteInterface;
 use Laminas\Router\RoutePluginManager;
 use LaminasTest\Router\RouterFactoryTest as TestCase;
 
@@ -14,7 +15,10 @@ final class HttpRouterFactoryTest extends TestCase
     {
         $this->defaultServiceConfig = [
             'factories' => [
-                'RoutePluginManager' => static fn($services) => new RoutePluginManager($services),
+                /**
+                 * @psalm-return RoutePluginManager<RouteInterface>
+                 */
+                'RoutePluginManager' => static fn($services): RoutePluginManager => new RoutePluginManager($services),
             ],
         ];
 

--- a/test/Http/LiteralTest.php
+++ b/test/Http/LiteralTest.php
@@ -62,13 +62,8 @@ final class LiteralTest extends TestCase
         ];
     }
 
-    /**
-     * @param        string   $path
-     * @param        int|null $offset
-     * @param        bool     $shouldMatch
-     */
     #[DataProvider('routeProvider')]
-    public function testMatching(Literal $route, $path, $offset, $shouldMatch)
+    public function testMatching(Literal $route, string $path, int|null $offset, bool $shouldMatch): void
     {
         $request = new Request();
         $request->setUri('http://example.com' . $path);
@@ -85,13 +80,8 @@ final class LiteralTest extends TestCase
         }
     }
 
-    /**
-     * @param        string   $path
-     * @param        int|null $offset
-     * @param        bool     $shouldMatch
-     */
     #[DataProvider('routeProvider')]
-    public function testAssembling(Literal $route, $path, $offset, $shouldMatch)
+    public function testAssembling(Literal $route, string $path, int|null $offset, bool $shouldMatch): void
     {
         if (! $shouldMatch) {
             // Data which will not match are not tested for assembling.
@@ -108,7 +98,7 @@ final class LiteralTest extends TestCase
         }
     }
 
-    public function testNoMatchWithoutUriMethod()
+    public function testNoMatchWithoutUriMethod(): void
     {
         $route   = new Literal('/foo');
         $request = new BaseRequest();
@@ -116,7 +106,7 @@ final class LiteralTest extends TestCase
         $this->assertNull($route->match($request));
     }
 
-    public function testGetAssembledParams()
+    public function testGetAssembledParams(): void
     {
         $route = new Literal('/foo');
         $route->assemble(['foo' => 'bar']);
@@ -124,7 +114,7 @@ final class LiteralTest extends TestCase
         $this->assertEquals([], $route->getAssembledParams());
     }
 
-    public function testFactory()
+    public function testFactory(): void
     {
         $tester = new FactoryTester($this);
         $tester->testFactory(
@@ -139,7 +129,7 @@ final class LiteralTest extends TestCase
     }
 
     #[Group('Laminas-436')]
-    public function testEmptyLiteral()
+    public function testEmptyLiteral(): void
     {
         $request = new Request();
         $route   = new Literal('');

--- a/test/Http/MethodTest.php
+++ b/test/Http/MethodTest.php
@@ -46,7 +46,7 @@ final class MethodTest extends TestCase
      * @param string $verb
      */
     #[DataProvider('routeProvider')]
-    public function testMatching(HttpMethod $route, $verb)
+    public function testMatching(HttpMethod $route, $verb): void
     {
         $request = new Request();
         $request->setUri('http://example.com');
@@ -56,7 +56,7 @@ final class MethodTest extends TestCase
         $this->assertInstanceOf(RouteMatch::class, $match);
     }
 
-    public function testNoMatchWithoutVerb()
+    public function testNoMatchWithoutVerb(): void
     {
         $route   = new HttpMethod('get');
         $request = new BaseRequest();
@@ -64,7 +64,7 @@ final class MethodTest extends TestCase
         $this->assertNull($route->match($request));
     }
 
-    public function testFactory()
+    public function testFactory(): void
     {
         $tester = new FactoryTester($this);
         $tester->testFactory(

--- a/test/Http/PartTest.php
+++ b/test/Http/PartTest.php
@@ -284,14 +284,14 @@ final class PartTest extends TestCase
         ];
     }
 
-    /**
-     * @param        string   $path
-     * @param        int|null $offset
-     * @param        string   $routeName
-     */
     #[DataProvider('routeProvider')]
-    public function testMatching(Part $route, $path, $offset, $routeName, ?array $params = null)
-    {
+    public function testMatching(
+        Part $route,
+        string $path,
+        int|null $offset,
+        ?string $routeName,
+        ?array $params = null
+    ): void {
         $request = new Request();
         $request->setUri('http://example.com' . $path);
         $match = $route->match($request, $offset);
@@ -313,14 +313,14 @@ final class PartTest extends TestCase
         }
     }
 
-    /**
-     * @param        string   $path
-     * @param        int|null $offset
-     * @param        string   $routeName
-     */
     #[DataProvider('routeProvider')]
-    public function testAssembling(Part $route, $path, $offset, $routeName, ?array $params = null)
-    {
+    public function testAssembling(
+        Part $route,
+        string $path,
+        int|null $offset,
+        ?string $routeName,
+        ?array $params = null
+    ): void {
         if ($params === null) {
             // Data which will not match are not tested for assembling.
             $this->expectNotToPerformAssertions();
@@ -336,14 +336,14 @@ final class PartTest extends TestCase
         }
     }
 
-    public function testAssembleNonTerminatedRoute()
+    public function testAssembleNonTerminatedRoute(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Part route may not terminate');
         self::getRoute()->assemble([], ['name' => 'baz']);
     }
 
-    public function testBaseRouteMayNotBePartRoute()
+    public function testBaseRouteMayNotBePartRoute(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Base route may not be a part route');
@@ -351,7 +351,7 @@ final class PartTest extends TestCase
         new Part(self::getRoute(), true, new RoutePluginManager(new ServiceManager()));
     }
 
-    public function testNoMatchWithoutUriMethod()
+    public function testNoMatchWithoutUriMethod(): void
     {
         $route   = self::getRoute();
         $request = new BaseRequest();
@@ -359,7 +359,7 @@ final class PartTest extends TestCase
         $this->assertNull($route->match($request));
     }
 
-    public function testGetAssembledParams()
+    public function testGetAssembledParams(): void
     {
         $route = self::getRoute();
         $route->assemble(['controller' => 'foo'], ['name' => 'baz/bat']);
@@ -367,7 +367,7 @@ final class PartTest extends TestCase
         $this->assertEquals([], $route->getAssembledParams());
     }
 
-    public function testFactory()
+    public function testFactory(): void
     {
         $tester = new FactoryTester($this);
         $tester->testFactory(
@@ -384,7 +384,7 @@ final class PartTest extends TestCase
     }
 
     #[Group('Laminas-105')]
-    public function testFactoryShouldAcceptTraversableChildRoutes()
+    public function testFactoryShouldAcceptTraversableChildRoutes(): void
     {
         $children = new ArrayObject([
             'create' => [
@@ -419,7 +419,7 @@ final class PartTest extends TestCase
     }
 
     #[Group('3711')]
-    public function testPartRouteMarkedAsMayTerminateCanMatchWhenQueryStringPresent()
+    public function testPartRouteMarkedAsMayTerminateCanMatchWhenQueryStringPresent(): void
     {
         $options = [
             'route'         => [
@@ -452,45 +452,10 @@ final class PartTest extends TestCase
         $request->setUri('http://example.com/resource?foo=bar');
         $query = new Parameters(['foo' => 'bar']);
         $request->setQuery($query);
-        $query = $request->getQuery();
+        $request->getQuery();
 
         $match = $route->match($request);
         $this->assertInstanceOf(\Laminas\Router\RouteMatch::class, $match);
         $this->assertEquals('resource', $match->getParam('action'));
-    }
-
-    #[Group('3711')]
-    public function testPartRouteMarkedAsMayTerminateButWithQueryRouteChildWillMatchChildRoute()
-    {
-        $options = [
-            'route'         => [
-                'type'    => Literal::class,
-                'options' => [
-                    'route'    => '/resource',
-                    'defaults' => [
-                        'controller' => 'ResourceController',
-                        'action'     => 'resource',
-                    ],
-                ],
-            ],
-            'route_plugins' => self::getRoutePlugins(),
-            'may_terminate' => true,
-        ];
-
-        $route   = Part::factory($options);
-        $request = new Request();
-        $request->setUri('http://example.com/resource?foo=bar');
-        $query = new Parameters(['foo' => 'bar']);
-        $request->setQuery($query);
-        $query = $request->getQuery();
-
-        /** @link https://github.com/laminas/laminas-router/commit/66ebd439067d9e25a6f7941de4b9ebc9c52524f5 */
-        $this->markTestSkipped('This test fails and has been skipped because the Query route has been deprecated (?)');
-
-        /*
-        $match = $route->match($request);
-        $this->assertInstanceOf(\Laminas\Router\RouteMatch::class, $match);
-        $this->assertEquals('string', $match->getParam('query'));
-        */
     }
 }

--- a/test/Http/PlaceholderTest.php
+++ b/test/Http/PlaceholderTest.php
@@ -45,7 +45,7 @@ final class PlaceholderTest extends TestCase
             ],
         ],
     ];
-    public function testMatch()
+    public function testMatch(): void
     {
         $route = new Placeholder([]);
 
@@ -56,31 +56,26 @@ final class PlaceholderTest extends TestCase
         $this->assertInstanceOf(RouteMatch::class, $match);
     }
 
-    public function testAssembling()
+    public function testAssembling(): void
     {
         $route = new Placeholder([]);
         $this->assertEquals('', $route->assemble());
     }
 
-    public function testGetAssembledParams()
+    public function testGetAssembledParams(): void
     {
         $route = new Placeholder([]);
         $this->assertEquals([], $route->getAssembledParams());
     }
 
-    public function testFactory()
+    public function testFactory(): void
     {
         $tester = new FactoryTester($this);
         $tester->testFactory(Placeholder::class, [], []);
     }
 
-    /**
-     * @param array $additionalConfig
-     * @param string $uri
-     * @param string $expectedRouteName
-     */
     #[DataProvider('placeholderProvider')]
-    public function testPlaceholderDefault($additionalConfig, $uri, $expectedRouteName)
+    public function testPlaceholderDefault(array $additionalConfig, string $uri, string $expectedRouteName): void
     {
         $routeConfig = ArrayUtils::merge(self::$routeConfig, $additionalConfig);
         $router      = TreeRouteStack::factory(['routes' => $routeConfig]);

--- a/test/Http/RegexTest.php
+++ b/test/Http/RegexTest.php
@@ -79,12 +79,8 @@ final class RegexTest extends TestCase
         ];
     }
 
-    /**
-     * @param        string   $path
-     * @param        int|null $offset
-     */
     #[DataProvider('routeProvider')]
-    public function testMatching(Regex $route, $path, $offset, ?array $params = null)
+    public function testMatching(Regex $route, string $path, int|null $offset, ?array $params = null): void
     {
         $request = new Request();
         $request->setUri('http://example.com' . $path);
@@ -105,12 +101,8 @@ final class RegexTest extends TestCase
         }
     }
 
-    /**
-     * @param        string   $path
-     * @param        int|null $offset
-     */
     #[DataProvider('routeProvider')]
-    public function testAssembling(Regex $route, $path, $offset, ?array $params = null)
+    public function testAssembling(Regex $route, string $path, int|null $offset, ?array $params = null): void
     {
         if ($params === null) {
             // Data which will not match are not tested for assembling.
@@ -127,7 +119,7 @@ final class RegexTest extends TestCase
         }
     }
 
-    public function testNoMatchWithoutUriMethod()
+    public function testNoMatchWithoutUriMethod(): void
     {
         $route   = new Regex('/foo', '/foo');
         $request = new BaseRequest();
@@ -135,7 +127,7 @@ final class RegexTest extends TestCase
         $this->assertNull($route->match($request));
     }
 
-    public function testGetAssembledParams()
+    public function testGetAssembledParams(): void
     {
         $route = new Regex('/(?<foo>.+)', '/%foo%');
         $route->assemble(['foo' => 'bar', 'baz' => 'bat']);
@@ -143,7 +135,7 @@ final class RegexTest extends TestCase
         $this->assertEquals(['foo'], $route->getAssembledParams());
     }
 
-    public function testFactory()
+    public function testFactory(): void
     {
         $tester = new FactoryTester($this);
         $tester->testFactory(
@@ -159,7 +151,7 @@ final class RegexTest extends TestCase
         );
     }
 
-    public function testRawDecode()
+    public function testRawDecode(): void
     {
         // verify all characters which don't absolutely require encoding pass through match unchanged
         // this includes every character other than #, %, / and ?
@@ -172,7 +164,7 @@ final class RegexTest extends TestCase
         $this->assertSame($raw, $match->getParam('foo'));
     }
 
-    public function testEncodedDecode()
+    public function testEncodedDecode(): void
     {
         // @codingStandardsIgnoreStart
         // every character

--- a/test/Http/RouteMatchTest.php
+++ b/test/Http/RouteMatchTest.php
@@ -9,21 +9,21 @@ use PHPUnit\Framework\TestCase;
 
 final class RouteMatchTest extends TestCase
 {
-    public function testParamsAreStored()
+    public function testParamsAreStored(): void
     {
         $match = new RouteMatch(['foo' => 'bar']);
 
         $this->assertEquals(['foo' => 'bar'], $match->getParams());
     }
 
-    public function testLengthIsStored()
+    public function testLengthIsStored(): void
     {
         $match = new RouteMatch([], 10);
 
         $this->assertEquals(10, $match->getLength());
     }
 
-    public function testLengthIsMerged()
+    public function testLengthIsMerged(): void
     {
         $match = new RouteMatch([], 10);
         $match->merge(new RouteMatch([], 5));
@@ -31,7 +31,7 @@ final class RouteMatchTest extends TestCase
         $this->assertEquals(15, $match->getLength());
     }
 
-    public function testMatchedRouteNameIsSet()
+    public function testMatchedRouteNameIsSet(): void
     {
         $match = new RouteMatch([]);
         $match->setMatchedRouteName('foo');
@@ -39,7 +39,7 @@ final class RouteMatchTest extends TestCase
         $this->assertEquals('foo', $match->getMatchedRouteName());
     }
 
-    public function testMatchedRouteNameIsPrependedWhenAlreadySet()
+    public function testMatchedRouteNameIsPrependedWhenAlreadySet(): void
     {
         $match = new RouteMatch([]);
         $match->setMatchedRouteName('foo');
@@ -48,7 +48,7 @@ final class RouteMatchTest extends TestCase
         $this->assertEquals('bar/foo', $match->getMatchedRouteName());
     }
 
-    public function testMatchedRouteNameIsOverriddenOnMerge()
+    public function testMatchedRouteNameIsOverriddenOnMerge(): void
     {
         $match = new RouteMatch([]);
         $match->setMatchedRouteName('foo');

--- a/test/Http/SchemeTest.php
+++ b/test/Http/SchemeTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 final class SchemeTest extends TestCase
 {
-    public function testMatching()
+    public function testMatching(): void
     {
         $request = new Request();
         $request->setUri('https://example.com/');
@@ -25,7 +25,7 @@ final class SchemeTest extends TestCase
         $this->assertInstanceOf(RouteMatch::class, $match);
     }
 
-    public function testNoMatchingOnDifferentScheme()
+    public function testNoMatchingOnDifferentScheme(): void
     {
         $request = new Request();
         $request->setUri('http://example.com/');
@@ -36,7 +36,7 @@ final class SchemeTest extends TestCase
         $this->assertNull($match);
     }
 
-    public function testAssembling()
+    public function testAssembling(): void
     {
         $uri   = new HttpUri();
         $route = new Scheme('https');
@@ -46,7 +46,7 @@ final class SchemeTest extends TestCase
         $this->assertEquals('https', $uri->getScheme());
     }
 
-    public function testNoMatchWithoutUriMethod()
+    public function testNoMatchWithoutUriMethod(): void
     {
         $route   = new Scheme('https');
         $request = new BaseRequest();
@@ -54,7 +54,7 @@ final class SchemeTest extends TestCase
         $this->assertNull($route->match($request));
     }
 
-    public function testGetAssembledParams()
+    public function testGetAssembledParams(): void
     {
         $route = new Scheme('https');
         $route->assemble(['foo' => 'bar']);
@@ -62,7 +62,7 @@ final class SchemeTest extends TestCase
         $this->assertEquals([], $route->getAssembledParams());
     }
 
-    public function testFactory()
+    public function testFactory(): void
     {
         $tester = new FactoryTester($this);
         $tester->testFactory(

--- a/test/Http/SegmentTest.php
+++ b/test/Http/SegmentTest.php
@@ -340,12 +340,13 @@ final class SegmentTest extends TestCase
         }
     }
 
-    /**
-     * @param        string   $path
-     * @param        int|null $offset
-     */
-    private function matchingWithL10n(Segment $route, $path, $offset, ?array $params = null, array $options = [])
-    {
+    private function matchingWithL10n(
+        Segment $route,
+        string $path,
+        int|null $offset,
+        ?array $params = null,
+        array $options = []
+    ): void {
         $request = new Request();
         $request->setUri('http://example.com' . $path);
         $match = $route->match($request, $offset, $options);
@@ -365,12 +366,13 @@ final class SegmentTest extends TestCase
         }
     }
 
-    /**
-     * @param        string   $path
-     * @param        int|null $offset
-     */
-    private function assemblingWithL10n(Segment $route, $path, $offset, ?array $params = null, array $options = [])
-    {
+    private function assemblingWithL10n(
+        Segment $route,
+        string $path,
+        int|null $offset,
+        ?array $params = null,
+        array $options = []
+    ): void {
         if ($params === null) {
             // Data which will not match are not tested for assembling.
             return;
@@ -385,20 +387,15 @@ final class SegmentTest extends TestCase
         }
     }
 
-    /**
-     * @param        string $route
-     * @param        string $exceptionName
-     * @param        string $exceptionMessage
-     */
     #[DataProvider('parseExceptionsProvider')]
-    public function testParseExceptions($route, $exceptionName, $exceptionMessage)
+    public function testParseExceptions(string $route, string $exceptionName, string $exceptionMessage): void
     {
         $this->expectException($exceptionName);
         $this->expectExceptionMessage($exceptionMessage);
         new Segment($route);
     }
 
-    public function testAssemblingWithMissingParameterInRoot()
+    public function testAssemblingWithMissingParameterInRoot(): void
     {
         $route = new Segment('/:foo');
 
@@ -407,7 +404,7 @@ final class SegmentTest extends TestCase
         $route->assemble();
     }
 
-    public function testTranslatedAssemblingThrowsExceptionWithoutTranslator()
+    public function testTranslatedAssemblingThrowsExceptionWithoutTranslator(): void
     {
         $route = new Segment('/{foo}');
 
@@ -416,7 +413,7 @@ final class SegmentTest extends TestCase
         $route->assemble();
     }
 
-    public function testTranslatedMatchingThrowsExceptionWithoutTranslator()
+    public function testTranslatedMatchingThrowsExceptionWithoutTranslator(): void
     {
         $route = new Segment('/{foo}');
 
@@ -425,7 +422,7 @@ final class SegmentTest extends TestCase
         $route->match(new Request());
     }
 
-    public function testNoMatchWithoutUriMethod()
+    public function testNoMatchWithoutUriMethod(): void
     {
         $route   = new Segment('/foo');
         $request = new BaseRequest();
@@ -433,7 +430,7 @@ final class SegmentTest extends TestCase
         $this->assertNull($route->match($request));
     }
 
-    public function testAssemblingWithExistingChild()
+    public function testAssemblingWithExistingChild(): void
     {
         $route = new Segment('/[:foo]', [], ['foo' => 'bar']);
         $path  = $route->assemble([], ['has_child' => true]);
@@ -441,7 +438,7 @@ final class SegmentTest extends TestCase
         $this->assertEquals('/bar', $path);
     }
 
-    public function testFactory()
+    public function testFactory(): void
     {
         $tester = new FactoryTester($this);
         $tester->testFactory(
@@ -456,7 +453,7 @@ final class SegmentTest extends TestCase
         );
     }
 
-    public function testRawDecode()
+    public function testRawDecode(): void
     {
         // verify all characters which don't absolutely require encoding pass through match unchanged
         // this includes every character other than #, %, / and ?
@@ -469,7 +466,7 @@ final class SegmentTest extends TestCase
         $this->assertSame($raw, $match->getParam('foo'));
     }
 
-    public function testEncodedDecode()
+    public function testEncodedDecode(): void
     {
         // @codingStandardsIgnoreStart
         // every character
@@ -485,7 +482,7 @@ final class SegmentTest extends TestCase
         $this->assertSame($out, $match->getParam('foo'));
     }
 
-    public function testEncodeCache()
+    public function testEncodeCache(): void
     {
         $params1 = ['p1' => 6.123, 'p2' => 7];
         $uri1    = 'example.com/' . implode('/', $params1);

--- a/test/Http/TestAsset/DummyRoute.php
+++ b/test/Http/TestAsset/DummyRoute.php
@@ -14,35 +14,25 @@ use Laminas\Stdlib\RequestInterface;
 class DummyRoute implements HttpRouteInterface
 {
     /**
-     * match(): defined by RouteInterface interface.
-     *
-     * @see    Route::match()
-     *
-     * @param  int $pathOffset
-     * @return RouteMatch
+     * @inheritDoc
      */
-    public function match(RequestInterface $request, $pathOffset = null)
-    {
+    public function match(
+        RequestInterface $request,
+        int|null $pathOffset = null
+    ) {
         return new RouteMatch(['offset' => $pathOffset], -4);
     }
 
     /**
-     * assemble(): defined by RouteInterface interface.
-     *
-     * @see    Route::assemble()
-     *
-     * @return mixed
+     * @inheritDoc
      */
-    public function assemble(?array $params = null, ?array $options = null)
+    public function assemble(array $params = [], array $options = [])
     {
         return '';
     }
 
     /**
-     * factory(): defined by RouteInterface interface
-     *
-     * @param  iterable $options
-     * @return DummyRoute
+     * @inheritDoc
      */
     public static function factory($options = [])
     {
@@ -50,11 +40,7 @@ class DummyRoute implements HttpRouteInterface
     }
 
     /**
-     * getAssembledParams(): defined by RouteInterface interface.
-     *
-     * @see    Route::getAssembledParams
-     *
-     * @return array
+     * @inheritDoc
      */
     public function getAssembledParams()
     {

--- a/test/Http/TestAsset/DummyRouteWithParam.php
+++ b/test/Http/TestAsset/DummyRouteWithParam.php
@@ -13,26 +13,19 @@ use Laminas\Stdlib\RequestInterface;
 final class DummyRouteWithParam extends DummyRoute
 {
     /**
-     * match(): defined by RouteInterface interface.
-     *
-     * @see    Route::match()
-     *
-     * @param  int $pathOffset
-     * @return RouteMatch
+     * @inheritDoc
      */
-    public function match(RequestInterface $request, $pathOffset = null)
-    {
+    public function match(
+        RequestInterface $request,
+        int|null $pathOffset = null
+    ) {
         return new RouteMatch(['foo' => 'bar'], -4);
     }
 
     /**
-     * assemble(): defined by RouteInterface interface.
-     *
-     * @see    Route::assemble()
-     *
-     * @return mixed
+     * @inheritDoc
      */
-    public function assemble(?array $params = null, ?array $options = null)
+    public function assemble(array $params = [], array $options = [])
     {
         return $params['foo'] ?? '';
     }

--- a/test/Http/TreeRouteStackTest.php
+++ b/test/Http/TreeRouteStackTest.php
@@ -20,7 +20,7 @@ use ReflectionClass;
 
 final class TreeRouteStackTest extends TestCase
 {
-    public function testAddRouteRequiresHttpSpecificRoute()
+    public function testAddRouteRequiresHttpSpecificRoute(): void
     {
         $stack = new TreeRouteStack();
 
@@ -30,7 +30,7 @@ final class TreeRouteStackTest extends TestCase
         $stack->addRoute('foo', new DummyRoute());
     }
 
-    public function testAddRouteViaStringRequiresHttpSpecificRoute()
+    public function testAddRouteViaStringRequiresHttpSpecificRoute(): void
     {
         $stack = new TreeRouteStack();
 
@@ -41,7 +41,7 @@ final class TreeRouteStackTest extends TestCase
         ]);
     }
 
-    public function testAddRouteAcceptsTraversable()
+    public function testAddRouteAcceptsTraversable(): void
     {
         $stack = new TreeRouteStack();
         $stack->addRoute('foo', new ArrayIterator([
@@ -50,7 +50,7 @@ final class TreeRouteStackTest extends TestCase
         $this->assertTrue($stack->hasRoute('foo'));
     }
 
-    public function testNoMatchWithoutUriMethod()
+    public function testNoMatchWithoutUriMethod(): void
     {
         $stack   = new TreeRouteStack();
         $request = new BaseRequest();
@@ -58,7 +58,7 @@ final class TreeRouteStackTest extends TestCase
         $this->assertNull($stack->match($request));
     }
 
-    public function testSetBaseUrlFromFirstMatch()
+    public function testSetBaseUrlFromFirstMatch(): void
     {
         $stack = new TreeRouteStack();
 
@@ -73,7 +73,7 @@ final class TreeRouteStackTest extends TestCase
         $this->assertEquals('/foo', $stack->getBaseUrl());
     }
 
-    public function testBaseUrlLengthIsPassedAsOffset()
+    public function testBaseUrlLengthIsPassedAsOffset(): void
     {
         $stack = new TreeRouteStack();
         $stack->setBaseUrl('/foo');
@@ -84,7 +84,7 @@ final class TreeRouteStackTest extends TestCase
         $this->assertEquals(4, $stack->match(new Request())->getParam('offset'));
     }
 
-    public function testNoOffsetIsPassedWithoutBaseUrl()
+    public function testNoOffsetIsPassedWithoutBaseUrl(): void
     {
         $stack = new TreeRouteStack();
         $stack->addRoute('foo', [
@@ -94,14 +94,14 @@ final class TreeRouteStackTest extends TestCase
         $this->assertEquals(null, $stack->match(new Request())->getParam('offset'));
     }
 
-    public function testAssemble()
+    public function testAssemble(): void
     {
         $stack = new TreeRouteStack();
         $stack->addRoute('foo', new TestAsset\DummyRoute());
         $this->assertEquals('', $stack->assemble([], ['name' => 'foo']));
     }
 
-    public function testAssembleCanonicalUriWithoutRequestUri()
+    public function testAssembleCanonicalUriWithoutRequestUri(): void
     {
         $stack = new TreeRouteStack();
         $stack->addRoute('foo', new TestAsset\DummyRoute());
@@ -111,7 +111,7 @@ final class TreeRouteStackTest extends TestCase
         $stack->assemble([], ['name' => 'foo', 'force_canonical' => true]);
     }
 
-    public function testAssembleCanonicalUriWithRequestUri()
+    public function testAssembleCanonicalUriWithRequestUri(): void
     {
         $uri   = new HttpUri('http://example.com:8080/');
         $stack = new TreeRouteStack();
@@ -124,7 +124,7 @@ final class TreeRouteStackTest extends TestCase
         );
     }
 
-    public function testAssembleCanonicalUriWithGivenUri()
+    public function testAssembleCanonicalUriWithGivenUri(): void
     {
         $uri   = new HttpUri('http://example.com:8080/');
         $stack = new TreeRouteStack();
@@ -136,7 +136,7 @@ final class TreeRouteStackTest extends TestCase
         );
     }
 
-    public function testAssembleCanonicalUriWithHostnameRoute()
+    public function testAssembleCanonicalUriWithHostnameRoute(): void
     {
         $stack = new TreeRouteStack();
         $stack->addRoute('foo', new Hostname('example.com'));
@@ -146,7 +146,7 @@ final class TreeRouteStackTest extends TestCase
         $this->assertEquals('http://example.com/', $stack->assemble([], ['name' => 'foo', 'uri' => $uri]));
     }
 
-    public function testAssembleCanonicalUriWithHostnameRouteWithoutScheme()
+    public function testAssembleCanonicalUriWithHostnameRouteWithoutScheme(): void
     {
         $stack = new TreeRouteStack();
         $stack->addRoute('foo', new Hostname('example.com'));
@@ -157,7 +157,7 @@ final class TreeRouteStackTest extends TestCase
         $stack->assemble([], ['name' => 'foo', 'uri' => $uri]);
     }
 
-    public function testAssembleCanonicalUriWithHostnameRouteAndRequestUriWithoutScheme()
+    public function testAssembleCanonicalUriWithHostnameRouteAndRequestUriWithoutScheme(): void
     {
         $uri = new HttpUri();
         $uri->setScheme('http');
@@ -168,7 +168,7 @@ final class TreeRouteStackTest extends TestCase
         $this->assertEquals('http://example.com/', $stack->assemble([], ['name' => 'foo']));
     }
 
-    public function testAssembleWithQueryParams()
+    public function testAssembleWithQueryParams(): void
     {
         $stack = new TreeRouteStack();
         $stack->addRoute(
@@ -184,7 +184,7 @@ final class TreeRouteStackTest extends TestCase
         $this->assertEquals('/?foo=bar', $stack->assemble([], ['name' => 'index', 'query' => ['foo' => 'bar']]));
     }
 
-    public function testAssembleWithEncodedPath()
+    public function testAssembleWithEncodedPath(): void
     {
         $stack = new TreeRouteStack();
         $stack->addRoute(
@@ -200,7 +200,7 @@ final class TreeRouteStackTest extends TestCase
         $this->assertEquals('/this%2Fthat', $stack->assemble([], ['name' => 'index']));
     }
 
-    public function testAssembleWithEncodedPathAndQueryParams()
+    public function testAssembleWithEncodedPathAndQueryParams(): void
     {
         $stack = new TreeRouteStack();
         $stack->addRoute(
@@ -219,7 +219,7 @@ final class TreeRouteStackTest extends TestCase
         );
     }
 
-    public function testAssembleWithScheme()
+    public function testAssembleWithScheme(): void
     {
         $uri = new HttpUri();
         $uri->setScheme('http');
@@ -246,7 +246,7 @@ final class TreeRouteStackTest extends TestCase
         $this->assertEquals('https://example.com/', $stack->assemble([], ['name' => 'secure/index']));
     }
 
-    public function testAssembleWithFragment()
+    public function testAssembleWithFragment(): void
     {
         $stack = new TreeRouteStack();
         $stack->addRoute(
@@ -262,7 +262,7 @@ final class TreeRouteStackTest extends TestCase
         $this->assertEquals('/#foobar', $stack->assemble([], ['name' => 'index', 'fragment' => 'foobar']));
     }
 
-    public function testAssembleWithoutNameOption()
+    public function testAssembleWithoutNameOption(): void
     {
         $stack = new TreeRouteStack();
 
@@ -271,7 +271,7 @@ final class TreeRouteStackTest extends TestCase
         $stack->assemble();
     }
 
-    public function testAssembleNonExistentRoute()
+    public function testAssembleNonExistentRoute(): void
     {
         $stack = new TreeRouteStack();
 
@@ -280,7 +280,7 @@ final class TreeRouteStackTest extends TestCase
         $stack->assemble([], ['name' => 'foo']);
     }
 
-    public function testAssembleNonExistentChildRoute()
+    public function testAssembleNonExistentChildRoute(): void
     {
         $stack = new TreeRouteStack();
         $stack->addRoute(
@@ -298,7 +298,7 @@ final class TreeRouteStackTest extends TestCase
         $stack->assemble([], ['name' => 'index/foo']);
     }
 
-    public function testDefaultParamIsAddedToMatch()
+    public function testDefaultParamIsAddedToMatch(): void
     {
         $stack = new TreeRouteStack();
         $stack->setBaseUrl('/foo');
@@ -308,7 +308,7 @@ final class TreeRouteStackTest extends TestCase
         $this->assertEquals('bar', $stack->match(new Request())->getParam('foo'));
     }
 
-    public function testDefaultParamDoesNotOverrideParam()
+    public function testDefaultParamDoesNotOverrideParam(): void
     {
         $stack = new TreeRouteStack();
         $stack->setBaseUrl('/foo');
@@ -318,7 +318,7 @@ final class TreeRouteStackTest extends TestCase
         $this->assertEquals('bar', $stack->match(new Request())->getParam('foo'));
     }
 
-    public function testDefaultParamIsUsedForAssembling()
+    public function testDefaultParamIsUsedForAssembling(): void
     {
         $stack = new TreeRouteStack();
         $stack->addRoute('foo', new TestAsset\DummyRouteWithParam());
@@ -327,7 +327,7 @@ final class TreeRouteStackTest extends TestCase
         $this->assertEquals('bar', $stack->assemble([], ['name' => 'foo']));
     }
 
-    public function testDefaultParamDoesNotOverrideParamForAssembling()
+    public function testDefaultParamDoesNotOverrideParamForAssembling(): void
     {
         $stack = new TreeRouteStack();
         $stack->addRoute('foo', new TestAsset\DummyRouteWithParam());
@@ -336,7 +336,7 @@ final class TreeRouteStackTest extends TestCase
         $this->assertEquals('bar', $stack->assemble(['foo' => 'bar'], ['name' => 'foo']));
     }
 
-    public function testSetBaseUrl()
+    public function testSetBaseUrl(): void
     {
         $stack = new TreeRouteStack();
 
@@ -344,7 +344,7 @@ final class TreeRouteStackTest extends TestCase
         $this->assertEquals('/foo', $stack->getBaseUrl());
     }
 
-    public function testSetRequestUri()
+    public function testSetRequestUri(): void
     {
         $uri   = new HttpUri();
         $stack = new TreeRouteStack();
@@ -353,7 +353,7 @@ final class TreeRouteStackTest extends TestCase
         $this->assertEquals($uri, $stack->getRequestUri());
     }
 
-    public function testPriorityIsPassedToPartRoute()
+    public function testPriorityIsPassedToPartRoute(): void
     {
         $stack = new TreeRouteStack();
         $stack->addRoutes([
@@ -384,13 +384,12 @@ final class TreeRouteStackTest extends TestCase
 
         $reflectedClass    = new ReflectionClass($stack);
         $reflectedProperty = $reflectedClass->getProperty('routes');
-        $reflectedProperty->setAccessible(true);
-        $routes = $reflectedProperty->getValue($stack);
+        $routes            = $reflectedProperty->getValue($stack);
 
         $this->assertEquals(1000, $routes->get('foo')->priority);
     }
 
-    public function testPrototypeRoute()
+    public function testPrototypeRoute(): void
     {
         $stack = new TreeRouteStack();
         $stack->addPrototype(
@@ -401,7 +400,7 @@ final class TreeRouteStackTest extends TestCase
         $this->assertEquals('/bar', $stack->assemble([], ['name' => 'foo']));
     }
 
-    public function testChainRouteAssembling()
+    public function testChainRouteAssembling(): void
     {
         $stack = new TreeRouteStack();
         $stack->addPrototype(
@@ -423,7 +422,7 @@ final class TreeRouteStackTest extends TestCase
         $this->assertEquals('/foo/bar', $stack->assemble([], ['name' => 'foo']));
     }
 
-    public function testChainRouteAssemblingWithChildrenAndSecureScheme()
+    public function testChainRouteAssemblingWithChildrenAndSecureScheme(): void
     {
         $stack = new TreeRouteStack();
 
@@ -454,7 +453,7 @@ final class TreeRouteStackTest extends TestCase
         $this->assertEquals('https://localhost/foo/baz', $stack->assemble([], ['name' => 'foo/baz']));
     }
 
-    public function testFactory()
+    public function testFactory(): void
     {
         $tester = new FactoryTester($this);
         $tester->testFactory(

--- a/test/RouteMatchTest.php
+++ b/test/RouteMatchTest.php
@@ -9,14 +9,14 @@ use PHPUnit\Framework\TestCase;
 
 final class RouteMatchTest extends TestCase
 {
-    public function testParamsAreStored()
+    public function testParamsAreStored(): void
     {
         $match = new RouteMatch(['foo' => 'bar']);
 
         $this->assertEquals(['foo' => 'bar'], $match->getParams());
     }
 
-    public function testMatchedRouteNameIsSet()
+    public function testMatchedRouteNameIsSet(): void
     {
         $match = new RouteMatch([]);
         $match->setMatchedRouteName('foo');
@@ -24,7 +24,7 @@ final class RouteMatchTest extends TestCase
         $this->assertEquals('foo', $match->getMatchedRouteName());
     }
 
-    public function testSetParam()
+    public function testSetParam(): void
     {
         $match = new RouteMatch([]);
         $match->setParam('foo', 'bar');
@@ -32,21 +32,21 @@ final class RouteMatchTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $match->getParams());
     }
 
-    public function testGetParam()
+    public function testGetParam(): void
     {
         $match = new RouteMatch(['foo' => 'bar']);
 
         $this->assertEquals('bar', $match->getParam('foo'));
     }
 
-    public function testGetNonExistentParamWithoutDefault()
+    public function testGetNonExistentParamWithoutDefault(): void
     {
         $match = new RouteMatch([]);
 
         $this->assertNull($match->getParam('foo'));
     }
 
-    public function testGetNonExistentParamWithDefault()
+    public function testGetNonExistentParamWithDefault(): void
     {
         $match = new RouteMatch([]);
 

--- a/test/RoutePluginManagerFactoryTest.php
+++ b/test/RoutePluginManagerFactoryTest.php
@@ -14,8 +14,7 @@ use Psr\Container\ContainerInterface;
 
 final class RoutePluginManagerFactoryTest extends TestCase
 {
-    /** @var ContainerInterface|MockObject */
-    private $container;
+    private ContainerInterface|MockObject $container;
     private RoutePluginManagerFactory $factory;
 
     public function setUp(): void
@@ -24,13 +23,13 @@ final class RoutePluginManagerFactoryTest extends TestCase
         $this->factory   = new RoutePluginManagerFactory();
     }
 
-    public function testInvocationReturnsAPluginManager()
+    public function testInvocationReturnsAPluginManager(): void
     {
         $plugins = $this->factory->__invoke($this->container, RoutePluginManager::class);
         $this->assertInstanceOf(RoutePluginManager::class, $plugins);
     }
 
-    public function testCreateServiceReturnsAPluginManager()
+    public function testCreateServiceReturnsAPluginManager(): void
     {
         $container = $this->createMock(ServiceLocatorInterface::class);
 
@@ -38,11 +37,11 @@ final class RoutePluginManagerFactoryTest extends TestCase
         $this->assertInstanceOf(RoutePluginManager::class, $plugins);
     }
 
-    public function testInvocationCanProvideOptionsToThePluginManager()
+    public function testInvocationCanProvideOptionsToThePluginManager(): void
     {
         $options = [
             'factories' => [
-                'TestRoute' => fn($container) => $this->createMock(RouteInterface::class),
+                'TestRoute' => fn($container): MockObject&RouteInterface => $this->createMock(RouteInterface::class),
             ],
         ];
         $plugins = $this->factory->__invoke(

--- a/test/RoutePluginManagerTest.php
+++ b/test/RoutePluginManagerTest.php
@@ -11,14 +11,14 @@ use PHPUnit\Framework\TestCase;
 
 final class RoutePluginManagerTest extends TestCase
 {
-    public function testLoadNonExistentRoute()
+    public function testLoadNonExistentRoute(): void
     {
         $routes = new RoutePluginManager(new ServiceManager());
         $this->expectException(ServiceNotFoundException::class);
         $routes->get('foo');
     }
 
-    public function testCanLoadAnyRoute()
+    public function testCanLoadAnyRoute(): void
     {
         $routes = new RoutePluginManager(new ServiceManager(), [
             'invokables' => [

--- a/test/RouterFactoryTest.php
+++ b/test/RouterFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LaminasTest\Router;
 
 use Laminas\Router\Http\HttpRouterFactory;
+use Laminas\Router\RouteInterface;
 use Laminas\Router\RoutePluginManager;
 use Laminas\Router\RouterFactory;
 use Laminas\ServiceManager\Config;
@@ -31,8 +32,11 @@ class RouterFactoryTest extends TestCase
     {
         $this->defaultServiceConfig = [
             'factories' => [
-                'HttpRouter'         => HttpRouterFactory::class,
-                'RoutePluginManager' => static fn($services) => new RoutePluginManager($services),
+                'HttpRouter' => HttpRouterFactory::class,
+                /**
+                 * @psalm-return RoutePluginManager<RouteInterface>
+                 */
+                'RoutePluginManager' => static fn($services): RoutePluginManager => new RoutePluginManager($services),
             ],
         ];
 

--- a/test/SimpleRouteStackTest.php
+++ b/test/SimpleRouteStackTest.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\TestCase;
 
 final class SimpleRouteStackTest extends TestCase
 {
-    public function testSetRoutePluginManager()
+    public function testSetRoutePluginManager(): void
     {
         $routes = new RoutePluginManager(new ServiceManager());
         $stack  = new SimpleRouteStack();
@@ -34,7 +34,7 @@ final class SimpleRouteStackTest extends TestCase
         $this->assertEquals($routes, $stack->getRoutePluginManager());
     }
 
-    public function testAddRoutesWithInvalidArgument()
+    public function testAddRoutesWithInvalidArgument(): void
     {
         $stack = new SimpleRouteStack();
 
@@ -43,7 +43,7 @@ final class SimpleRouteStackTest extends TestCase
         $stack->addRoutes('foo');
     }
 
-    public function testAddRoutesAsArray()
+    public function testAddRoutesAsArray(): void
     {
         $stack = new SimpleRouteStack();
         $stack->addRoutes([
@@ -53,7 +53,7 @@ final class SimpleRouteStackTest extends TestCase
         $this->assertInstanceOf(RouteMatch::class, $stack->match(new Request()));
     }
 
-    public function testAddRoutesAsTraversable()
+    public function testAddRoutesAsTraversable(): void
     {
         $stack = new SimpleRouteStack();
         $stack->addRoutes(new ArrayIterator([
@@ -63,7 +63,7 @@ final class SimpleRouteStackTest extends TestCase
         $this->assertInstanceOf(RouteMatch::class, $stack->match(new Request()));
     }
 
-    public function testSetRoutesWithInvalidArgument()
+    public function testSetRoutesWithInvalidArgument(): void
     {
         $stack = new SimpleRouteStack();
 
@@ -72,7 +72,7 @@ final class SimpleRouteStackTest extends TestCase
         $stack->setRoutes('foo');
     }
 
-    public function testSetRoutesAsArray()
+    public function testSetRoutesAsArray(): void
     {
         $stack = new SimpleRouteStack();
         $stack->setRoutes([
@@ -86,7 +86,7 @@ final class SimpleRouteStackTest extends TestCase
         $this->assertNull($stack->match(new Request()));
     }
 
-    public function testSetRoutesAsTraversable()
+    public function testSetRoutesAsTraversable(): void
     {
         $stack = new SimpleRouteStack();
         $stack->setRoutes(new ArrayIterator([
@@ -100,7 +100,7 @@ final class SimpleRouteStackTest extends TestCase
         $this->assertNull($stack->match(new Request()));
     }
 
-    public function testremoveRouteAsArray()
+    public function testremoveRouteAsArray(): void
     {
         $stack = new SimpleRouteStack();
         $stack->addRoutes([
@@ -111,7 +111,7 @@ final class SimpleRouteStackTest extends TestCase
         $this->assertNull($stack->match(new Request()));
     }
 
-    public function testAddRouteWithInvalidArgument()
+    public function testAddRouteWithInvalidArgument(): void
     {
         $stack = new SimpleRouteStack();
 
@@ -121,7 +121,7 @@ final class SimpleRouteStackTest extends TestCase
         $stack->addRoute('foo', 'bar');
     }
 
-    public function testAddRouteAsArrayWithoutOptions()
+    public function testAddRouteAsArrayWithoutOptions(): void
     {
         $stack = new SimpleRouteStack();
         $stack->addRoute('foo', [
@@ -131,7 +131,7 @@ final class SimpleRouteStackTest extends TestCase
         $this->assertInstanceOf(RouteMatch::class, $stack->match(new Request()));
     }
 
-    public function testAddRouteAsArrayWithOptions()
+    public function testAddRouteAsArrayWithOptions(): void
     {
         $stack = new SimpleRouteStack();
         $stack->addRoute('foo', [
@@ -142,7 +142,7 @@ final class SimpleRouteStackTest extends TestCase
         $this->assertInstanceOf(RouteMatch::class, $stack->match(new Request()));
     }
 
-    public function testAddRouteAsArrayWithoutType()
+    public function testAddRouteAsArrayWithoutType(): void
     {
         $stack = new SimpleRouteStack();
 
@@ -151,7 +151,7 @@ final class SimpleRouteStackTest extends TestCase
         $stack->addRoute('foo', []);
     }
 
-    public function testAddRouteAsArrayWithPriority()
+    public function testAddRouteAsArrayWithPriority(): void
     {
         $stack = new SimpleRouteStack();
 
@@ -166,7 +166,7 @@ final class SimpleRouteStackTest extends TestCase
         $this->assertEquals('bar', $stack->match(new Request())->getParam('foo'));
     }
 
-    public function testAddRouteWithPriority()
+    public function testAddRouteWithPriority(): void
     {
         $stack = new SimpleRouteStack();
 
@@ -182,7 +182,7 @@ final class SimpleRouteStackTest extends TestCase
         $this->assertEquals('bar', $stack->match(new Request())->getParam('foo'));
     }
 
-    public function testAddRouteAsTraversable()
+    public function testAddRouteAsTraversable(): void
     {
         $stack = new SimpleRouteStack();
         $stack->addRoute('foo', new ArrayIterator([
@@ -192,14 +192,14 @@ final class SimpleRouteStackTest extends TestCase
         $this->assertInstanceOf(RouteMatch::class, $stack->match(new Request()));
     }
 
-    public function testAssemble()
+    public function testAssemble(): void
     {
         $stack = new SimpleRouteStack();
         $stack->addRoute('foo', new TestAsset\DummyRoute());
         $this->assertEquals('', $stack->assemble([], ['name' => 'foo']));
     }
 
-    public function testAssembleWithoutNameOption()
+    public function testAssembleWithoutNameOption(): void
     {
         $stack = new SimpleRouteStack();
 
@@ -208,7 +208,7 @@ final class SimpleRouteStackTest extends TestCase
         $stack->assemble();
     }
 
-    public function testAssembleNonExistentRoute()
+    public function testAssembleNonExistentRoute(): void
     {
         $stack = new SimpleRouteStack();
 
@@ -217,7 +217,7 @@ final class SimpleRouteStackTest extends TestCase
         $stack->assemble([], ['name' => 'foo']);
     }
 
-    public function testDefaultParamIsAddedToMatch()
+    public function testDefaultParamIsAddedToMatch(): void
     {
         $stack = new SimpleRouteStack();
         $stack->addRoute('foo', new TestAsset\DummyRoute());
@@ -226,7 +226,7 @@ final class SimpleRouteStackTest extends TestCase
         $this->assertEquals('bar', $stack->match(new Request())->getParam('foo'));
     }
 
-    public function testDefaultParamDoesNotOverrideParam()
+    public function testDefaultParamDoesNotOverrideParam(): void
     {
         $stack = new SimpleRouteStack();
         $stack->addRoute('foo', new TestAsset\DummyRouteWithParam());
@@ -235,7 +235,7 @@ final class SimpleRouteStackTest extends TestCase
         $this->assertEquals('bar', $stack->match(new Request())->getParam('foo'));
     }
 
-    public function testDefaultParamIsUsedForAssembling()
+    public function testDefaultParamIsUsedForAssembling(): void
     {
         $stack = new SimpleRouteStack();
         $stack->addRoute('foo', new TestAsset\DummyRouteWithParam());
@@ -244,7 +244,7 @@ final class SimpleRouteStackTest extends TestCase
         $this->assertEquals('bar', $stack->assemble([], ['name' => 'foo']));
     }
 
-    public function testDefaultParamDoesNotOverrideParamForAssembling()
+    public function testDefaultParamDoesNotOverrideParamForAssembling(): void
     {
         $stack = new SimpleRouteStack();
         $stack->addRoute('foo', new TestAsset\DummyRouteWithParam());
@@ -253,7 +253,7 @@ final class SimpleRouteStackTest extends TestCase
         $this->assertEquals('bar', $stack->assemble(['foo' => 'bar'], ['name' => 'foo']));
     }
 
-    public function testFactory()
+    public function testFactory(): void
     {
         $tester = new FactoryTester($this);
         $tester->testFactory(
@@ -267,13 +267,13 @@ final class SimpleRouteStackTest extends TestCase
         );
     }
 
-    public function testGetRoutes()
+    public function testGetRoutes(): void
     {
         $stack = new SimpleRouteStack();
         $this->assertInstanceOf('Traversable', $stack->getRoutes());
     }
 
-    public function testGetRouteByName()
+    public function testGetRouteByName(): void
     {
         $stack = new SimpleRouteStack();
         $route = new TestAsset\DummyRoute();
@@ -282,7 +282,7 @@ final class SimpleRouteStackTest extends TestCase
         $this->assertEquals($route, $stack->getRoute('foo'));
     }
 
-    public function testHasRoute()
+    public function testHasRoute(): void
     {
         $stack = new SimpleRouteStack();
         $this->assertEquals(false, $stack->hasRoute('foo'));

--- a/test/TestAsset/DummyRoute.php
+++ b/test/TestAsset/DummyRoute.php
@@ -13,15 +13,14 @@ use Laminas\Stdlib\RequestInterface;
  */
 class DummyRoute implements RouteInterface
 {
-    /** @deprecated Setting priority with a public property should be factored out in the next major */
+    /**
+     * @internal
+     * @deprecated Since 3.9.0 This property will be removed or made private in version 4.0
+     */
     public ?int $priority = null;
 
     /**
-     * match(): defined by RouteInterface interface.
-     *
-     * @see    Route::match()
-     *
-     * @return RouteMatch
+     * @inheritDoc
      */
     public function match(RequestInterface $request)
     {
@@ -29,22 +28,15 @@ class DummyRoute implements RouteInterface
     }
 
     /**
-     * assemble(): defined by RouteInterface interface.
-     *
-     * @see    Route::assemble()
-     *
-     * @return mixed
+     * @inheritDoc
      */
-    public function assemble(?array $params = null, ?array $options = null)
+    public function assemble(array $params = [], array $options = [])
     {
         return '';
     }
 
     /**
-     * factory(): defined by RouteInterface interface
-     *
-     * @param iterable $options
-     * @return DummyRoute
+     * @inheritDoc
      */
     public static function factory($options = [])
     {

--- a/test/TestAsset/DummyRouteWithParam.php
+++ b/test/TestAsset/DummyRouteWithParam.php
@@ -13,11 +13,7 @@ use Laminas\Stdlib\RequestInterface;
 final class DummyRouteWithParam extends DummyRoute
 {
     /**
-     * match(): defined by RouteInterface interface.
-     *
-     * @see    Route::match()
-     *
-     * @return RouteMatch
+     * @inheritDoc
      */
     public function match(RequestInterface $request)
     {
@@ -25,13 +21,9 @@ final class DummyRouteWithParam extends DummyRoute
     }
 
     /**
-     * assemble(): defined by RouteInterface interface.
-     *
-     * @see    Route::assemble()
-     *
-     * @return mixed
+     * @inheritDoc
      */
-    public function assemble(?array $params = null, ?array $options = null)
+    public function assemble(array $params = [], array $options = [])
     {
         return $params['foo'] ?? '';
     }

--- a/test/TestAsset/Router.php
+++ b/test/TestAsset/Router.php
@@ -16,10 +16,7 @@ use Laminas\Stdlib\RequestInterface as Request;
 final class Router implements RouteStackInterface
 {
     /**
-     * Create a new route with given options.
-     *
-     * @param iterable $options
-     * @return self
+     * @inheritDoc
      */
     public static function factory($options = [])
     {
@@ -27,21 +24,19 @@ final class Router implements RouteStackInterface
     }
 
     /**
-     * Match a given request.
-     *
-     * @return RouteMatch|null
+     * @inheritDoc
      */
     public function match(Request $request)
     {
+        return null;
     }
 
     /**
-     * Assemble the route.
-     *
-     * @return mixed
+     * @inheritDoc
      */
     public function assemble(array $params = [], array $options = [])
     {
+        return null;
     }
 
     /** @inheritDoc */


### PR DESCRIPTION
- Update test classes to include explicit `void` return types for all test methods, improving type consistency.
- Remove redundant `@param` and `@return` annotations.
- Update Psalm baseline to reflect these changes.
