### PR TITLE
Remove laminas/laminas-i18n in favor of laminas/laminas-translator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,18 +32,18 @@
     },
     "require": {
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
-        "laminas/laminas-servicemanager": "^3.14.0",
-        "laminas/laminas-stdlib": "^3.10.1",
+        "laminas/laminas-servicemanager": "^3.24.0",
+        "laminas/laminas-stdlib": "^3.21.0",
         "laminas/laminas-uri": "^2.14",
-        "psr/container": "^1 || ^2.0.2"
+        "psr/container": "^1.1.2 || ^2.0.2",
+        "laminas/laminas-translator": "^1.3"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~3.1.0",
-        "laminas/laminas-http": "^2.22",
-        "laminas/laminas-i18n": "^2.31.0",
-        "phpunit/phpunit": "^11.5.43",
+        "laminas/laminas-http": "^2.23",
+        "phpunit/phpunit": "^11.5.55",
         "psalm/plugin-phpunit": "^0.19.5",
-        "vimeo/psalm": "^6.13.1"
+        "vimeo/psalm": "^6.15.1"
     },
     "suggest": {
         "laminas/laminas-i18n": "^2.15.0 if defining translatable HTTP path segments"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dec0ee49223b677f8a46d99a4566f89d",
+    "content-hash": "3d3a7ee5fe6fc3e4e07770386e2e6316",
     "packages": [
         {
             "name": "laminas/laminas-escaper",
@@ -215,6 +215,60 @@
                 }
             ],
             "time": "2025-10-11T18:13:12+00:00"
+        },
+        {
+            "name": "laminas/laminas-translator",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-translator.git",
+                "reference": "1d6bf7d857c3fc310a30f5ea028731b9bf8be9db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-translator/zipball/1d6bf7d857c3fc310a30f5ea028731b9bf8be9db",
+                "reference": "1d6bf7d857c3fc310a30f5ea028731b9bf8be9db",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "phpunit/phpunit": "^11.5.46",
+                "vimeo/psalm": "^6.14.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Translator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Interfaces for the Translator component of laminas-i18n",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "i18n",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-i18n/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-translator/issues",
+                "rss": "https://github.com/laminas/laminas-translator/releases.atom",
+                "source": "https://github.com/laminas/laminas-translator"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-12-30T14:26:45+00:00"
         },
         {
             "name": "laminas/laminas-uri",
@@ -2062,95 +2116,6 @@
             "time": "2025-12-05T11:02:08+00:00"
         },
         {
-            "name": "laminas/laminas-i18n",
-            "version": "2.32.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-i18n.git",
-                "reference": "8e71b40318f0df6253329e837188e1d77cf83aea"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-i18n/zipball/8e71b40318f0df6253329e837188e1d77cf83aea",
-                "reference": "8e71b40318f0df6253329e837188e1d77cf83aea",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "ext-intl": "*",
-                "laminas/laminas-escaper": "^2.0",
-                "laminas/laminas-servicemanager": "^3.21.0",
-                "laminas/laminas-stdlib": "^3.0",
-                "laminas/laminas-translator": "^1.0",
-                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
-                "psr/container": "^1.0.0"
-            },
-            "conflict": {
-                "laminas/laminas-view": "<2.20.0",
-                "zendframework/zend-i18n": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-cache": "^3.13.0",
-                "laminas/laminas-cache-storage-adapter-memory": "^2.4.0",
-                "laminas/laminas-cache-storage-deprecated-factory": "^1.3",
-                "laminas/laminas-coding-standard": "^3.1",
-                "laminas/laminas-config": "^3.10.1",
-                "laminas/laminas-eventmanager": "^3.15.0",
-                "laminas/laminas-filter": "^2.42",
-                "laminas/laminas-validator": "^2.65.0",
-                "laminas/laminas-view": "^2.44",
-                "phpunit/phpunit": "^11.5.46",
-                "psalm/plugin-phpunit": "^0.19.5",
-                "vimeo/psalm": "^6.14.2"
-            },
-            "suggest": {
-                "laminas/laminas-cache": "You should install this package to cache the translations",
-                "laminas/laminas-config": "You should install this package to use the INI translation format",
-                "laminas/laminas-eventmanager": "You should install this package to use the events in the translator",
-                "laminas/laminas-filter": "You should install this package to use the provided filters",
-                "laminas/laminas-i18n-resources": "This package provides validator and captcha translations",
-                "laminas/laminas-validator": "You should install this package to use the provided validators",
-                "laminas/laminas-view": "You should install this package to use the provided view helpers"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "component": "Laminas\\I18n",
-                    "config-provider": "Laminas\\I18n\\ConfigProvider"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\I18n\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Provide translations for your application, and filter and validate internationalized values",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "i18n",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-i18n/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-i18n/issues",
-                "rss": "https://github.com/laminas/laminas-i18n/releases.atom",
-                "source": "https://github.com/laminas/laminas-i18n"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2025-12-15T14:23:40+00:00"
-        },
-        {
             "name": "laminas/laminas-loader",
             "version": "2.12.0",
             "source": {
@@ -2206,60 +2171,6 @@
             ],
             "abandoned": true,
             "time": "2025-12-30T11:30:39+00:00"
-        },
-        {
-            "name": "laminas/laminas-translator",
-            "version": "1.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-translator.git",
-                "reference": "1d6bf7d857c3fc310a30f5ea028731b9bf8be9db"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-translator/zipball/1d6bf7d857c3fc310a30f5ea028731b9bf8be9db",
-                "reference": "1d6bf7d857c3fc310a30f5ea028731b9bf8be9db",
-                "shasum": ""
-            },
-            "require": {
-                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~3.1.0",
-                "phpunit/phpunit": "^11.5.46",
-                "vimeo/psalm": "^6.14.3"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Translator\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Interfaces for the Translator component of laminas-i18n",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "i18n",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-i18n/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-translator/issues",
-                "rss": "https://github.com/laminas/laminas-translator/releases.atom",
-                "source": "https://github.com/laminas/laminas-translator"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2025-12-30T14:26:45+00:00"
         },
         {
             "name": "league/uri",
@@ -6021,5 +5932,5 @@
     "platform-overrides": {
         "php": "8.2.99"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -387,26 +387,10 @@
     </UnsupportedReferenceUsage>
   </file>
   <file src="src/Http/TranslatorAwareTreeRouteStack.php">
-    <DeprecatedInterface>
-      <code><![CDATA[?Translator]]></code>
-      <code><![CDATA[Translator]]></code>
-      <code><![CDATA[Translator]]></code>
-    </DeprecatedInterface>
-    <LessSpecificImplementedReturnType>
-      <code><![CDATA[TreeRouteStack]]></code>
-      <code><![CDATA[TreeRouteStack]]></code>
-    </LessSpecificImplementedReturnType>
-    <PossiblyNullPropertyAssignmentValue>
-      <code><![CDATA[$translator]]></code>
-    </PossiblyNullPropertyAssignmentValue>
     <PropertyNotSetInConstructor>
-      <code><![CDATA[$translator]]></code>
       <code><![CDATA[TranslatorAwareTreeRouteStack]]></code>
       <code><![CDATA[TranslatorAwareTreeRouteStack]]></code>
     </PropertyNotSetInConstructor>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[$this->translator !== null]]></code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Http/TreeRouteStack.php">
     <DeprecatedClass>
@@ -742,11 +726,6 @@
       <code><![CDATA[$value]]></code>
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
-    <NullArgument>
-      <code><![CDATA[null]]></code>
-      <code><![CDATA[null]]></code>
-      <code><![CDATA[null]]></code>
-    </NullArgument>
     <PossiblyNullReference>
       <code><![CDATA[getParam]]></code>
       <code><![CDATA[getParam]]></code>
@@ -756,12 +735,6 @@
     <UnsafeInstantiation>
       <code><![CDATA[new static()]]></code>
     </UnsafeInstantiation>
-  </file>
-  <file src="test/Http/TranslatorAwareTreeRouteStackTest.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[assertNull]]></code>
-      <code><![CDATA[assertNull]]></code>
-    </DocblockTypeContradiction>
   </file>
   <file src="test/Http/TreeRouteStackTest.php">
     <InvalidArgument>

--- a/src/Http/Segment.php
+++ b/src/Http/Segment.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Laminas\Router\Http;
 
-use Laminas\I18n\Translator\TranslatorInterface as Translator;
 use Laminas\Router\Exception;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface;
+use Laminas\Translator\TranslatorInterface as Translator;
 use Override;
 use Traversable;
 

--- a/src/Http/TranslatorAwareTreeRouteStack.php
+++ b/src/Http/TranslatorAwareTreeRouteStack.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Router\Http;
 
-use Laminas\I18n\Translator\TranslatorAwareInterface;
-use Laminas\I18n\Translator\TranslatorInterface as Translator;
 use Laminas\Router\Exception;
 use Laminas\Stdlib\RequestInterface;
+use Laminas\Translator\TranslatorInterface;
 use Override;
 
 /**
@@ -17,28 +16,22 @@ use Override;
  * @template-extends TreeRouteStack<TRoute>
  * @final
  */
-class TranslatorAwareTreeRouteStack extends TreeRouteStack implements TranslatorAwareInterface
+class TranslatorAwareTreeRouteStack extends TreeRouteStack
 {
     /**
      * Translator used for translatable segments.
-     *
-     * @var Translator
      */
-    protected $translator;
+    protected ?TranslatorInterface $translator = null;
 
     /**
      * Whether the translator is enabled.
-     *
-     * @var bool
      */
-    protected $translatorEnabled = true;
+    protected bool $translatorEnabled = true;
 
     /**
      * Translator text domain to use.
-     *
-     * @var string
      */
-    protected $translatorTextDomain = 'default';
+    protected string $translatorTextDomain = 'default';
 
     /**
      * @inheritDoc
@@ -77,16 +70,7 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
         return parent::assemble($params, $options);
     }
 
-    /**
-     * setTranslator(): defined by TranslatorAwareInterface.
-     *
-     * @see    TranslatorAwareInterface::setTranslator()
-     *
-     * @param  string     $textDomain
-     * @return TreeRouteStack
-     */
-    #[Override]
-    public function setTranslator(?Translator $translator = null, $textDomain = null)
+    public function setTranslator(?TranslatorInterface $translator = null, ?string $textDomain = null): self
     {
         $this->translator = $translator;
 
@@ -97,85 +81,35 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
         return $this;
     }
 
-    /**
-     * getTranslator(): defined by TranslatorAwareInterface.
-     *
-     * @see    TranslatorAwareInterface::getTranslator()
-     *
-     * @return Translator
-     */
-    #[Override]
-    public function getTranslator()
+    public function getTranslator(): ?TranslatorInterface
     {
         return $this->translator;
     }
 
-    /**
-     * hasTranslator(): defined by TranslatorAwareInterface.
-     *
-     * @see    TranslatorAwareInterface::hasTranslator()
-     *
-     * @return bool
-     */
-    #[Override]
-    public function hasTranslator()
+    public function hasTranslator(): bool
     {
         return $this->translator !== null;
     }
 
-    /**
-     * setTranslatorEnabled(): defined by TranslatorAwareInterface.
-     *
-     * @see    TranslatorAwareInterface::setTranslatorEnabled()
-     *
-     * @param  bool $enabled
-     * @return TreeRouteStack
-     */
-    #[Override]
-    public function setTranslatorEnabled($enabled = true)
+    public function setTranslatorEnabled(bool $enabled = true): self
     {
         $this->translatorEnabled = $enabled;
         return $this;
     }
 
-    /**
-     * isTranslatorEnabled(): defined by TranslatorAwareInterface.
-     *
-     * @see    TranslatorAwareInterface::isTranslatorEnabled()
-     *
-     * @return bool
-     */
-    #[Override]
-    public function isTranslatorEnabled()
+    public function isTranslatorEnabled(): bool
     {
         return $this->translatorEnabled;
     }
 
-    /**
-     * setTranslatorTextDomain(): defined by TranslatorAwareInterface.
-     *
-     * @see    TranslatorAwareInterface::setTranslatorTextDomain()
-     *
-     * @param  string $textDomain
-     * @return self
-     */
-    #[Override]
-    public function setTranslatorTextDomain($textDomain = 'default')
+    public function setTranslatorTextDomain(string $textDomain = 'default'): self
     {
         $this->translatorTextDomain = $textDomain;
 
         return $this;
     }
 
-    /**
-     * getTranslatorTextDomain(): defined by TranslatorAwareInterface.
-     *
-     * @see    TranslatorAwareInterface::getTranslatorTextDomain()
-     *
-     * @return string
-     */
-    #[Override]
-    public function getTranslatorTextDomain()
+    public function getTranslatorTextDomain(): string
     {
         return $this->translatorTextDomain;
     }

--- a/test/Http/SegmentTest.php
+++ b/test/Http/SegmentTest.php
@@ -183,7 +183,7 @@ final class SegmentTest extends TestCase
     public function testL10nRoute(): void
     {
         $translator = $this->createMock(TranslatorInterface::class);
-        $translator->expects($this->any())
+        $translator->expects($this->exactly(8))
             ->method('translate')
             ->willReturnCallback(function (
                 string $message,

--- a/test/Http/SegmentTest.php
+++ b/test/Http/SegmentTest.php
@@ -5,17 +5,16 @@ declare(strict_types=1);
 namespace LaminasTest\Router\Http;
 
 use Laminas\Http\Request;
-use Laminas\I18n\Translator\Loader\FileLoaderInterface;
-use Laminas\I18n\Translator\TextDomain;
-use Laminas\I18n\Translator\Translator;
 use Laminas\Router\Exception\InvalidArgumentException;
 use Laminas\Router\Exception\RuntimeException;
 use Laminas\Router\Http\HttpRouteMatch;
 use Laminas\Router\Http\Segment;
 use Laminas\Stdlib\Request as BaseRequest;
+use Laminas\Translator\TranslatorInterface;
 use LaminasTest\Router\FactoryTester;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
 
 use function implode;
 use function strlen;
@@ -183,23 +182,36 @@ final class SegmentTest extends TestCase
 
     public function testL10nRoute(): void
     {
-        $translator = new Translator();
-        $translator->setLocale('en-US');
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->expects($this->any())
+            ->method('translate')
+            ->willReturnCallback(function (
+                string $message,
+                string $textDomain = 'default',
+                ?string $locale = null
+            ): string {
+                if ($message === 'fw' && $textDomain === 'default' && $locale === null) {
+                    return 'framework';
+                }
 
-        $enLoader     = $this->createMock(FileLoaderInterface::class);
-        $deLoader     = $this->createMock(FileLoaderInterface::class);
-        $domainLoader = $this->createMock(FileLoaderInterface::class);
+                if ($message === 'fw' && $textDomain === 'default' && $locale === 'de-DE') {
+                    return 'baukasten';
+                }
 
-        $enLoader->expects($this->any())->method('load')->willReturn(new TextDomain(['fw' => 'framework']));
-        $deLoader->expects($this->any())->method('load')->willReturn(new TextDomain(['fw' => 'baukasten']));
-        $domainLoader->expects($this->any())->method('load')->willReturn(new TextDomain(['fw' => 'fw-alternative']));
+                if ($message === 'fw' && $textDomain === 'alternative' && $locale === null) {
+                    return 'fw-alternative';
+                }
 
-        $translator->getPluginManager()->setService('test-en', $enLoader);
-        $translator->getPluginManager()->setService('test-de', $deLoader);
-        $translator->getPluginManager()->setService('test-domain', $domainLoader);
-        $translator->addTranslationFile('test-en', null, 'default', 'en-US');
-        $translator->addTranslationFile('test-de', null, 'default', 'de-DE');
-        $translator->addTranslationFile('test-domain', null, 'alternative', 'en-US');
+                if ($message === 'fw' && $textDomain === 'default' && $locale === 'fr-FR') {
+                    return 'fw';
+                }
+
+                if ($message === 'fw' && $textDomain === 'default') {
+                    return 'framework';
+                }
+
+                throw new UnexpectedValueException('Translation not found');
+            });
 
         $this->matchingWithL10n(
             new Segment('/{fw}', [], []),

--- a/test/Http/TranslatorAwareTreeRouteStackTest.php
+++ b/test/Http/TranslatorAwareTreeRouteStackTest.php
@@ -5,31 +5,49 @@ declare(strict_types=1);
 namespace LaminasTest\Router\Http;
 
 use Laminas\Http\Request;
-use Laminas\I18n\Translator\Translator;
-use Laminas\I18n\Translator\TranslatorAwareInterface;
 use Laminas\Router\Http\HttpRouteInterface;
 use Laminas\Router\Http\TranslatorAwareTreeRouteStack;
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Uri\Http as HttpUri;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
 
 final class TranslatorAwareTreeRouteStackTest extends TestCase
 {
-    /** @var string */
-    protected $testFilesDir;
-
-    /** @var Translator */
-    protected $translator;
+    protected TranslatorInterface&MockObject $translator;
 
     /** @var array */
     protected $fooRoute;
 
     public function setUp(): void
     {
-        $this->testFilesDir = __DIR__ . '/_files';
+        $this->translator = $this->createMock(TranslatorInterface::class);
+        $this->translator->expects($this->any())
+                   ->method('translate')
+                   ->willReturnCallback(function (
+                       string $message,
+                       string $textDomain = 'default',
+                       ?string $locale = null
+                   ): string {
+                    if ($message === 'homepage' && $textDomain === 'default' && $locale === null) {
+                        return 'homepage';
+                    }
 
-        $this->translator = new Translator();
-        $this->translator->addTranslationFile('phpArray', $this->testFilesDir . '/tokens.en.php', 'route', 'en');
-        $this->translator->addTranslationFile('phpArray', $this->testFilesDir . '/tokens.de.php', 'route', 'de');
+                    if ($message === 'homepage' && $textDomain === 'route' && $locale === 'en') {
+                        return 'homepage';
+                    }
+
+                    if ($message === 'homepage' && $textDomain === 'route' && $locale === 'de') {
+                        return 'hauptseite';
+                    }
+
+                    if ($message === 'homepage' && $textDomain === 'default' && $locale === 'de-DE') {
+                        return 'hauptseite';
+                    }
+
+                    throw new UnexpectedValueException('Translation not found');
+                   });
 
         $this->fooRoute = [
             'type'         => 'Segment',
@@ -50,7 +68,6 @@ final class TranslatorAwareTreeRouteStackTest extends TestCase
     public function testTranslatorAwareInterfaceImplementation(): void
     {
         $stack = new TranslatorAwareTreeRouteStack();
-        $this->assertInstanceOf(TranslatorAwareInterface::class, $stack);
 
         // Defaults
         $this->assertNull($stack->getTranslator());
@@ -59,7 +76,7 @@ final class TranslatorAwareTreeRouteStackTest extends TestCase
         $this->assertTrue($stack->isTranslatorEnabled());
 
         // Inject translator without text domain
-        $translator = new Translator();
+        $translator = $this->createMock(TranslatorInterface::class);
         $stack->setTranslator($translator);
         $this->assertSame($translator, $stack->getTranslator());
         $this->assertEquals('default', $stack->getTranslatorTextDomain());
@@ -86,7 +103,7 @@ final class TranslatorAwareTreeRouteStackTest extends TestCase
 
     public function testTranslatorIsPassedThroughMatchMethod(): void
     {
-        $translator = new Translator();
+        $translator = $this->createMock(TranslatorInterface::class);
         $request    = new Request();
 
         $route = $this->createMock(HttpRouteInterface::class);
@@ -106,7 +123,7 @@ final class TranslatorAwareTreeRouteStackTest extends TestCase
 
     public function testTranslatorIsPassedThroughAssembleMethod(): void
     {
-        $translator = new Translator();
+        $translator = $this->createMock(TranslatorInterface::class);
         $uri        = new HttpUri();
 
         $route = $this->createMock(HttpRouteInterface::class);

--- a/test/Http/TranslatorAwareTreeRouteStackTest.php
+++ b/test/Http/TranslatorAwareTreeRouteStackTest.php
@@ -76,7 +76,7 @@ final class TranslatorAwareTreeRouteStackTest extends TestCase
         $this->assertTrue($stack->isTranslatorEnabled());
 
         // Inject translator without text domain
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $stack->setTranslator($translator);
         $this->assertSame($translator, $stack->getTranslator());
         $this->assertEquals('default', $stack->getTranslatorTextDomain());

--- a/test/Http/TranslatorAwareTreeRouteStackTest.php
+++ b/test/Http/TranslatorAwareTreeRouteStackTest.php
@@ -103,7 +103,7 @@ final class TranslatorAwareTreeRouteStackTest extends TestCase
 
     public function testTranslatorIsPassedThroughMatchMethod(): void
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $request    = new Request();
 
         $route = $this->createMock(HttpRouteInterface::class);

--- a/test/Http/TranslatorAwareTreeRouteStackTest.php
+++ b/test/Http/TranslatorAwareTreeRouteStackTest.php
@@ -15,54 +15,51 @@ use UnexpectedValueException;
 
 final class TranslatorAwareTreeRouteStackTest extends TestCase
 {
-    protected TranslatorInterface&MockObject $translator;
-
-    /** @var array */
-    protected $fooRoute;
-
-    public function setUp(): void
-    {
-        $this->translator = $this->createMock(TranslatorInterface::class);
-        $this->translator->expects($this->any())
-                   ->method('translate')
-                   ->willReturnCallback(function (
-                       string $message,
-                       string $textDomain = 'default',
-                       ?string $locale = null
-                   ): string {
-                    if ($message === 'homepage' && $textDomain === 'default' && $locale === null) {
-                        return 'homepage';
-                    }
-
-                    if ($message === 'homepage' && $textDomain === 'route' && $locale === 'en') {
-                        return 'homepage';
-                    }
-
-                    if ($message === 'homepage' && $textDomain === 'route' && $locale === 'de') {
-                        return 'hauptseite';
-                    }
-
-                    if ($message === 'homepage' && $textDomain === 'default' && $locale === 'de-DE') {
-                        return 'hauptseite';
-                    }
-
-                    throw new UnexpectedValueException('Translation not found');
-                   });
-
-        $this->fooRoute = [
-            'type'         => 'Segment',
-            'options'      => [
-                'route' => '/:locale',
-            ],
-            'child_routes' => [
-                'index' => [
-                    'type'    => 'Segment',
-                    'options' => [
-                        'route' => '/{homepage}',
-                    ],
+    private array $fooRoute = [
+        'type'         => 'Segment',
+        'options'      => [
+            'route' => '/:locale',
+        ],
+        'child_routes' => [
+            'index' => [
+                'type'    => 'Segment',
+                'options' => [
+                    'route' => '/{homepage}',
                 ],
             ],
-        ];
+        ],
+    ];
+
+    private function getTranslator(int $expectedCallCount): TranslatorInterface&MockObject
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->expects($this->exactly($expectedCallCount))
+            ->method('translate')
+            ->willReturnCallback(function (
+                string $message,
+                string $textDomain = 'default',
+                ?string $locale = null
+            ): string {
+                if ($message === 'homepage' && $textDomain === 'default' && $locale === null) {
+                    return 'homepage';
+                }
+
+                if ($message === 'homepage' && $textDomain === 'route' && $locale === 'en') {
+                    return 'homepage';
+                }
+
+                if ($message === 'homepage' && $textDomain === 'route' && $locale === 'de') {
+                    return 'hauptseite';
+                }
+
+                if ($message === 'homepage' && $textDomain === 'default' && $locale === 'de-DE') {
+                    return 'hauptseite';
+                }
+
+                throw new UnexpectedValueException('Translation not found');
+            });
+
+        return $translator;
     }
 
     public function testTranslatorAwareInterfaceImplementation(): void
@@ -143,7 +140,7 @@ final class TranslatorAwareTreeRouteStackTest extends TestCase
     public function testAssembleRouteWithParameterLocale(): void
     {
         $stack = new TranslatorAwareTreeRouteStack();
-        $stack->setTranslator($this->translator, 'route');
+        $stack->setTranslator($this->getTranslator(2), 'route');
         $stack->addRoute(
             'foo',
             $this->fooRoute
@@ -156,7 +153,7 @@ final class TranslatorAwareTreeRouteStackTest extends TestCase
     public function testMatchRouteWithParameterLocale(): void
     {
         $stack = new TranslatorAwareTreeRouteStack();
-        $stack->setTranslator($this->translator, 'route');
+        $stack->setTranslator($this->getTranslator(1), 'route');
         $stack->addRoute(
             'foo',
             $this->fooRoute

--- a/test/Http/TranslatorAwareTreeRouteStackTest.php
+++ b/test/Http/TranslatorAwareTreeRouteStackTest.php
@@ -123,7 +123,7 @@ final class TranslatorAwareTreeRouteStackTest extends TestCase
 
     public function testTranslatorIsPassedThroughAssembleMethod(): void
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $uri        = new HttpUri();
 
         $route = $this->createMock(HttpRouteInterface::class);

--- a/test/Http/_files/tokens.de.php
+++ b/test/Http/_files/tokens.de.php
@@ -1,7 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-return [
-    'homepage' => 'hauptseite',
-];

--- a/test/Http/_files/tokens.en.php
+++ b/test/Http/_files/tokens.en.php
@@ -1,7 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-return [
-    'homepage' => 'homepage',
-];


### PR DESCRIPTION
- Remove `laminas/laminas-i18n` from `composer.json`.
- Add `laminas/laminas-translator` to dependencies in `composer.json`.
- Adjust tests to mock `Laminas\Translator\TranslatorInterface` instead of relying on `laminas-i18n`.
- Update `psalm-baseline.xml` due to translator-related changes.
- Replace `Laminas\I18n\Translator\TranslatorInterface` with `Laminas\Translator\TranslatorInterface` in `Segment` and `TranslatorAwareTreeRouteStack`.
- remove usage of `TranslatorAwareInterface`