### PR TITLE
Rename Laminas\Router\Http\RouteMatch to HttpRouteMatch

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -119,6 +119,14 @@
       <code><![CDATA[$levelParts[$level + 1] = &$levelParts[$level][count($levelParts[$level]) - 1][1]]]></code>
     </UnsupportedReferenceUsage>
   </file>
+  <file src="src/Http/HttpRouteMatch.php">
+    <DeprecatedClass>
+      <code><![CDATA[RouteMatch]]></code>
+    </DeprecatedClass>
+    <PropertyNotSetInConstructor>
+      <code><![CDATA[HttpRouteMatch]]></code>
+    </PropertyNotSetInConstructor>
+  </file>
   <file src="src/Http/HttpRouterFactory.php">
     <DeprecatedInterface>
       <code><![CDATA[HttpRouterFactory]]></code>

--- a/src/Http/Chain.php
+++ b/src/Http/Chain.php
@@ -118,7 +118,7 @@ class Chain extends TreeRouteStack implements HttpRouteInterface
             $this->chainRoutes = null;
         }
 
-        $match      = new RouteMatch([]);
+        $match      = new HttpRouteMatch([]);
         $uri        = $request->getUri();
         $pathLength = strlen($uri->getPath());
 

--- a/src/Http/Hostname.php
+++ b/src/Http/Hostname.php
@@ -327,7 +327,7 @@ class Hostname implements HttpRouteInterface
             }
         }
 
-        return new RouteMatch(array_merge($this->defaults, $params));
+        return new HttpRouteMatch(array_merge($this->defaults, $params));
     }
 
     /**

--- a/src/Http/HttpRouteInterface.php
+++ b/src/Http/HttpRouteInterface.php
@@ -13,7 +13,7 @@ use Laminas\Stdlib\RequestInterface as Request;
  * Note: the additional {@see self::match()} annotation is only here for documentation purposes, because we cannot
  *       change the signature of {@see self::match()} in the interface definition without breaking BC.
  *
- * @method HttpRouteMatch|null match(Request $request, int|null $pathOffset = null, array $options = [])
+ * @method RouteMatch|null match(Request $request, int|null $pathOffset = null, array $options = [])
  */
 interface HttpRouteInterface extends RouteInterface
 {

--- a/src/Http/HttpRouteInterface.php
+++ b/src/Http/HttpRouteInterface.php
@@ -13,7 +13,7 @@ use Laminas\Stdlib\RequestInterface as Request;
  * Note: the additional {@see self::match()} annotation is only here for documentation purposes, because we cannot
  *       change the signature of {@see self::match()} in the interface definition without breaking BC.
  *
- * @method RouteMatch|null match(Request $request, int|null $pathOffset = null, array $options = [])
+ * @method HttpRouteMatch|null match(Request $request, int|null $pathOffset = null, array $options = [])
  */
 interface HttpRouteInterface extends RouteInterface
 {

--- a/src/Http/HttpRouteMatch.php
+++ b/src/Http/HttpRouteMatch.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Router\Http;
+
+/**
+ * Part route match.
+ */
+class HttpRouteMatch extends RouteMatch
+{
+}

--- a/src/Http/HttpRouteMatch.php
+++ b/src/Http/HttpRouteMatch.php
@@ -6,6 +6,8 @@ namespace Laminas\Router\Http;
 
 /**
  * Part route match.
+ *
+ * @final
  */
 class HttpRouteMatch extends RouteMatch
 {

--- a/src/Http/Literal.php
+++ b/src/Http/Literal.php
@@ -92,7 +92,7 @@ class Literal implements HttpRouteInterface
         if ($pathOffset !== null) {
             if ($pathOffset >= 0 && strlen((string) $path) >= $pathOffset && ! empty($this->route)) {
                 if (strpos($path, $this->route, $pathOffset) === $pathOffset) {
-                    return new RouteMatch($this->defaults, strlen($this->route));
+                    return new HttpRouteMatch($this->defaults, strlen($this->route));
                 }
             }
 
@@ -100,7 +100,7 @@ class Literal implements HttpRouteInterface
         }
 
         if ($path === $this->route) {
-            return new RouteMatch($this->defaults, strlen($this->route));
+            return new HttpRouteMatch($this->defaults, strlen($this->route));
         }
 
         return null;

--- a/src/Http/Method.php
+++ b/src/Http/Method.php
@@ -92,7 +92,7 @@ class Method implements HttpRouteInterface
         $matchVerbs  = array_map('trim', $matchVerbs);
 
         if (in_array($requestVerb, $matchVerbs)) {
-            return new RouteMatch($this->defaults);
+            return new HttpRouteMatch($this->defaults);
         }
 
         return null;

--- a/src/Http/Placeholder.php
+++ b/src/Http/Placeholder.php
@@ -63,7 +63,7 @@ class Placeholder implements HttpRouteInterface
      */
     public function match(Request $request, $pathOffset = null)
     {
-        return new RouteMatch($this->defaults);
+        return new HttpRouteMatch($this->defaults);
     }
 
     /**

--- a/src/Http/Regex.php
+++ b/src/Http/Regex.php
@@ -135,7 +135,7 @@ class Regex implements HttpRouteInterface
             }
         }
 
-        return new RouteMatch(array_merge($this->defaults, $matches), $matchedLength);
+        return new HttpRouteMatch(array_merge($this->defaults, $matches), $matchedLength);
     }
 
     /**

--- a/src/Http/RouteMatch.php
+++ b/src/Http/RouteMatch.php
@@ -11,7 +11,8 @@ use function array_merge;
 /**
  * Part route match.
  *
- * @deprecated Use HttpRouteMatch instead; this will be removed in v4.0
+ * @deprecated This class will become an interface in version 4 with
+ *              `Laminas\Router\HttpRouteMatch` as a final implementation
  */
 class RouteMatch extends BaseRouteMatch
 {

--- a/src/Http/RouteMatch.php
+++ b/src/Http/RouteMatch.php
@@ -10,6 +10,8 @@ use function array_merge;
 
 /**
  * Part route match.
+ *
+ * @deprecated Use HttpRouteMatch instead; this will be removed in v4.0
  */
 class RouteMatch extends BaseRouteMatch
 {

--- a/src/Http/Scheme.php
+++ b/src/Http/Scheme.php
@@ -90,7 +90,7 @@ class Scheme implements HttpRouteInterface
             return null;
         }
 
-        return new RouteMatch($this->defaults);
+        return new HttpRouteMatch($this->defaults);
     }
 
     /**

--- a/src/Http/Segment.php
+++ b/src/Http/Segment.php
@@ -405,7 +405,7 @@ class Segment implements HttpRouteInterface
             }
         }
 
-        return new RouteMatch(array_merge($this->defaults, $params), $matchedLength);
+        return new HttpRouteMatch(array_merge($this->defaults, $params), $matchedLength);
     }
 
     /**

--- a/src/Http/TreeRouteStack.php
+++ b/src/Http/TreeRouteStack.php
@@ -308,7 +308,7 @@ class TreeRouteStack extends SimpleRouteStack
 
         foreach ($this->routes as $name => $route) {
             if (
-                ($match = $route->match($request, $baseUrlLength, $options)) instanceof HttpRouteMatch
+                ($match = $route->match($request, $baseUrlLength, $options)) instanceof RouteMatch
                 && ($pathLength === null || $match->getLength() === $pathLength)
             ) {
                 $match->setMatchedRouteName($name);

--- a/src/Http/TreeRouteStack.php
+++ b/src/Http/TreeRouteStack.php
@@ -308,7 +308,7 @@ class TreeRouteStack extends SimpleRouteStack
 
         foreach ($this->routes as $name => $route) {
             if (
-                ($match = $route->match($request, $baseUrlLength, $options)) instanceof RouteMatch
+                ($match = $route->match($request, $baseUrlLength, $options)) instanceof HttpRouteMatch
                 && ($pathLength === null || $match->getLength() === $pathLength)
             ) {
                 $match->setMatchedRouteName($name);

--- a/src/Http/Wildcard.php
+++ b/src/Http/Wildcard.php
@@ -109,7 +109,7 @@ class Wildcard implements HttpRouteInterface
      * @see    RouteInterface::match()
      *
      * @param  integer|null $pathOffset
-     * @return RouteMatch|null
+     * @return HttpRouteMatch|null
      */
     public function match(Request $request, $pathOffset = null)
     {
@@ -155,7 +155,7 @@ class Wildcard implements HttpRouteInterface
             }
         }
 
-        return new RouteMatch(array_merge($this->defaults, $matches), strlen($path));
+        return new HttpRouteMatch(array_merge($this->defaults, $matches), strlen($path));
     }
 
     /**

--- a/test/Http/ChainTest.php
+++ b/test/Http/ChainTest.php
@@ -7,7 +7,7 @@ namespace LaminasTest\Router\Http;
 use Laminas\Http\Request;
 use Laminas\Router\Http\Chain;
 use Laminas\Router\Http\HttpRouteInterface;
-use Laminas\Router\Http\RouteMatch;
+use Laminas\Router\Http\HttpRouteMatch;
 use Laminas\Router\Http\Segment;
 use Laminas\Router\Http\Wildcard;
 use Laminas\Router\RoutePluginManager;
@@ -153,7 +153,7 @@ final class ChainTest extends TestCase
         if ($params === null) {
             $this->assertNull($match);
         } else {
-            $this->assertInstanceOf(RouteMatch::class, $match);
+            $this->assertInstanceOf(HttpRouteMatch::class, $match);
 
             if ($offset === null) {
                 $this->assertEquals(strlen($path), $match->getLength());

--- a/test/Http/HostnameTest.php
+++ b/test/Http/HostnameTest.php
@@ -8,7 +8,7 @@ use Laminas\Http\Request;
 use Laminas\Router\Exception\InvalidArgumentException;
 use Laminas\Router\Exception\RuntimeException;
 use Laminas\Router\Http\Hostname;
-use Laminas\Router\Http\RouteMatch;
+use Laminas\Router\Http\HttpRouteMatch;
 use Laminas\Stdlib\Request as BaseRequest;
 use Laminas\Uri\Http as HttpUri;
 use LaminasTest\Router\FactoryTester;
@@ -175,7 +175,7 @@ final class HostnameTest extends TestCase
         if ($params === null) {
             $this->assertNull($match);
         } else {
-            $this->assertInstanceOf(RouteMatch::class, $match);
+            $this->assertInstanceOf(HttpRouteMatch::class, $match);
 
             foreach ($params as $key => $value) {
                 $this->assertEquals($value, $match->getParam($key));
@@ -232,7 +232,7 @@ final class HostnameTest extends TestCase
         $request->setUri('/relative/path');
 
         $match = $route->match($request);
-        self::assertInstanceOf(RouteMatch::class, $match);
+        self::assertInstanceOf(HttpRouteMatch::class, $match);
         self::assertArrayNotHasKey('domain', $match->getParams());
     }
 

--- a/test/Http/LiteralTest.php
+++ b/test/Http/LiteralTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace LaminasTest\Router\Http;
 
 use Laminas\Http\Request;
+use Laminas\Router\Http\HttpRouteMatch;
 use Laminas\Router\Http\Literal;
-use Laminas\Router\Http\RouteMatch;
 use Laminas\Stdlib\Request as BaseRequest;
 use LaminasTest\Router\FactoryTester;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -72,7 +72,7 @@ final class LiteralTest extends TestCase
         if (! $shouldMatch) {
             $this->assertNull($match);
         } else {
-            $this->assertInstanceOf(RouteMatch::class, $match);
+            $this->assertInstanceOf(HttpRouteMatch::class, $match);
 
             if ($offset === null) {
                 $this->assertEquals(strlen($path), $match->getLength());

--- a/test/Http/MethodTest.php
+++ b/test/Http/MethodTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace LaminasTest\Router\Http;
 
 use Laminas\Http\Request;
+use Laminas\Router\Http\HttpRouteMatch;
 use Laminas\Router\Http\Method as HttpMethod;
-use Laminas\Router\Http\RouteMatch;
 use Laminas\Stdlib\Request as BaseRequest;
 use LaminasTest\Router\FactoryTester;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -50,7 +50,7 @@ final class MethodTest extends TestCase
         $request->setMethod($verb);
 
         $match = $route->match($request);
-        $this->assertInstanceOf(RouteMatch::class, $match);
+        $this->assertInstanceOf(HttpRouteMatch::class, $match);
     }
 
     public function testNoMatchWithoutVerb(): void

--- a/test/Http/PartTest.php
+++ b/test/Http/PartTest.php
@@ -9,12 +9,13 @@ use Laminas\Http\Request;
 use Laminas\Router\Exception\InvalidArgumentException;
 use Laminas\Router\Exception\RuntimeException;
 use Laminas\Router\Http\HttpRouteInterface;
+use Laminas\Router\Http\HttpRouteMatch;
 use Laminas\Router\Http\Literal;
 use Laminas\Router\Http\Part;
-use Laminas\Router\Http\RouteMatch;
 use Laminas\Router\Http\Segment;
 use Laminas\Router\Http\Wildcard;
 use Laminas\Router\RouteInvokableFactory;
+use Laminas\Router\RouteMatch;
 use Laminas\Router\RoutePluginManager;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Stdlib\Parameters;
@@ -299,7 +300,7 @@ final class PartTest extends TestCase
         if ($params === null) {
             $this->assertNull($match);
         } else {
-            $this->assertInstanceOf(RouteMatch::class, $match);
+            $this->assertInstanceOf(HttpRouteMatch::class, $match);
 
             if ($offset === null) {
                 $this->assertEquals(strlen($path), $match->getLength());
@@ -455,7 +456,7 @@ final class PartTest extends TestCase
         $request->getQuery();
 
         $match = $route->match($request);
-        $this->assertInstanceOf(\Laminas\Router\RouteMatch::class, $match);
+        $this->assertInstanceOf(RouteMatch::class, $match);
         $this->assertEquals('resource', $match->getParam('action'));
     }
 }

--- a/test/Http/PlaceholderTest.php
+++ b/test/Http/PlaceholderTest.php
@@ -6,9 +6,9 @@ namespace LaminasTest\Router\Http;
 
 use Laminas\Http\Request;
 use Laminas\Router\Http\Hostname;
+use Laminas\Router\Http\HttpRouteMatch;
 use Laminas\Router\Http\Literal;
 use Laminas\Router\Http\Placeholder;
-use Laminas\Router\Http\RouteMatch;
 use Laminas\Router\Http\TreeRouteStack;
 use Laminas\Stdlib\ArrayUtils;
 use LaminasTest\Router\FactoryTester;
@@ -53,7 +53,7 @@ final class PlaceholderTest extends TestCase
         $request->setUri('http://example.com/');
         $match = $route->match($request);
 
-        $this->assertInstanceOf(RouteMatch::class, $match);
+        $this->assertInstanceOf(HttpRouteMatch::class, $match);
     }
 
     public function testAssembling(): void
@@ -84,7 +84,7 @@ final class PlaceholderTest extends TestCase
         $request->setUri($uri);
         $match = $router->match($request);
 
-        $this->assertInstanceOf(RouteMatch::class, $match);
+        $this->assertInstanceOf(HttpRouteMatch::class, $match);
         $this->assertEquals($expectedRouteName, $match->getMatchedRouteName());
     }
 

--- a/test/Http/RegexTest.php
+++ b/test/Http/RegexTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace LaminasTest\Router\Http;
 
 use Laminas\Http\Request;
+use Laminas\Router\Http\HttpRouteMatch;
 use Laminas\Router\Http\Regex;
-use Laminas\Router\Http\RouteMatch;
 use Laminas\Stdlib\Request as BaseRequest;
 use LaminasTest\Router\FactoryTester;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -89,7 +89,7 @@ final class RegexTest extends TestCase
         if ($params === null) {
             $this->assertNull($match);
         } else {
-            $this->assertInstanceOf(RouteMatch::class, $match);
+            $this->assertInstanceOf(HttpRouteMatch::class, $match);
 
             if ($offset === null) {
                 $this->assertEquals(strlen($path), $match->getLength());

--- a/test/Http/RouteMatchTest.php
+++ b/test/Http/RouteMatchTest.php
@@ -4,36 +4,36 @@ declare(strict_types=1);
 
 namespace LaminasTest\Router\Http;
 
-use Laminas\Router\Http\RouteMatch;
+use Laminas\Router\Http\HttpRouteMatch;
 use PHPUnit\Framework\TestCase;
 
 final class RouteMatchTest extends TestCase
 {
     public function testParamsAreStored(): void
     {
-        $match = new RouteMatch(['foo' => 'bar']);
+        $match = new HttpRouteMatch(['foo' => 'bar']);
 
         $this->assertEquals(['foo' => 'bar'], $match->getParams());
     }
 
     public function testLengthIsStored(): void
     {
-        $match = new RouteMatch([], 10);
+        $match = new HttpRouteMatch([], 10);
 
         $this->assertEquals(10, $match->getLength());
     }
 
     public function testLengthIsMerged(): void
     {
-        $match = new RouteMatch([], 10);
-        $match->merge(new RouteMatch([], 5));
+        $match = new HttpRouteMatch([], 10);
+        $match->merge(new HttpRouteMatch([], 5));
 
         $this->assertEquals(15, $match->getLength());
     }
 
     public function testMatchedRouteNameIsSet(): void
     {
-        $match = new RouteMatch([]);
+        $match = new HttpRouteMatch([]);
         $match->setMatchedRouteName('foo');
 
         $this->assertEquals('foo', $match->getMatchedRouteName());
@@ -41,7 +41,7 @@ final class RouteMatchTest extends TestCase
 
     public function testMatchedRouteNameIsPrependedWhenAlreadySet(): void
     {
-        $match = new RouteMatch([]);
+        $match = new HttpRouteMatch([]);
         $match->setMatchedRouteName('foo');
         $match->setMatchedRouteName('bar');
 
@@ -50,10 +50,10 @@ final class RouteMatchTest extends TestCase
 
     public function testMatchedRouteNameIsOverriddenOnMerge(): void
     {
-        $match = new RouteMatch([]);
+        $match = new HttpRouteMatch([]);
         $match->setMatchedRouteName('foo');
 
-        $subMatch = new RouteMatch([]);
+        $subMatch = new HttpRouteMatch([]);
         $subMatch->setMatchedRouteName('bar');
 
         $match->merge($subMatch);

--- a/test/Http/SchemeTest.php
+++ b/test/Http/SchemeTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace LaminasTest\Router\Http;
 
 use Laminas\Http\Request;
-use Laminas\Router\Http\RouteMatch;
+use Laminas\Router\Http\HttpRouteMatch;
 use Laminas\Router\Http\Scheme;
 use Laminas\Stdlib\Request as BaseRequest;
 use Laminas\Uri\Http as HttpUri;
@@ -22,7 +22,7 @@ final class SchemeTest extends TestCase
         $route = new Scheme('https');
         $match = $route->match($request);
 
-        $this->assertInstanceOf(RouteMatch::class, $match);
+        $this->assertInstanceOf(HttpRouteMatch::class, $match);
     }
 
     public function testNoMatchingOnDifferentScheme(): void

--- a/test/Http/SegmentTest.php
+++ b/test/Http/SegmentTest.php
@@ -10,7 +10,7 @@ use Laminas\I18n\Translator\TextDomain;
 use Laminas\I18n\Translator\Translator;
 use Laminas\Router\Exception\InvalidArgumentException;
 use Laminas\Router\Exception\RuntimeException;
-use Laminas\Router\Http\RouteMatch;
+use Laminas\Router\Http\HttpRouteMatch;
 use Laminas\Router\Http\Segment;
 use Laminas\Stdlib\Request as BaseRequest;
 use LaminasTest\Router\FactoryTester;
@@ -305,7 +305,7 @@ final class SegmentTest extends TestCase
         if ($params === null) {
             $this->assertNull($match);
         } else {
-            $this->assertInstanceOf(RouteMatch::class, $match);
+            $this->assertInstanceOf(HttpRouteMatch::class, $match);
 
             if ($offset === null) {
                 $this->assertEquals(strlen($path), $match->getLength());
@@ -354,7 +354,7 @@ final class SegmentTest extends TestCase
         if ($params === null) {
             $this->assertNull($match);
         } else {
-            $this->assertInstanceOf(RouteMatch::class, $match);
+            $this->assertInstanceOf(HttpRouteMatch::class, $match);
 
             if ($offset === null) {
                 $this->assertEquals(strlen($path), $match->getLength());

--- a/test/Http/TestAsset/DummyRoute.php
+++ b/test/Http/TestAsset/DummyRoute.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace LaminasTest\Router\Http\TestAsset;
 
 use Laminas\Router\Http\HttpRouteInterface;
-use Laminas\Router\Http\RouteMatch;
+use Laminas\Router\Http\HttpRouteMatch;
 use Laminas\Stdlib\RequestInterface;
 
 /**
@@ -20,7 +20,7 @@ class DummyRoute implements HttpRouteInterface
         RequestInterface $request,
         int|null $pathOffset = null
     ) {
-        return new RouteMatch(['offset' => $pathOffset], -4);
+        return new HttpRouteMatch(['offset' => $pathOffset], -4);
     }
 
     /**

--- a/test/Http/TestAsset/DummyRouteWithParam.php
+++ b/test/Http/TestAsset/DummyRouteWithParam.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\Router\Http\TestAsset;
 
-use Laminas\Router\Http\RouteMatch;
+use Laminas\Router\Http\HttpRouteMatch;
 use Laminas\Stdlib\RequestInterface;
 
 /**
@@ -19,7 +19,7 @@ final class DummyRouteWithParam extends DummyRoute
         RequestInterface $request,
         int|null $pathOffset = null
     ) {
-        return new RouteMatch(['foo' => 'bar'], -4);
+        return new HttpRouteMatch(['foo' => 'bar'], -4);
     }
 
     /**

--- a/test/Http/WildcardTest.php
+++ b/test/Http/WildcardTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace LaminasTest\Router\Http;
 
 use Laminas\Http\Request;
-use Laminas\Router\Http\RouteMatch;
+use Laminas\Router\Http\HttpRouteMatch;
 use Laminas\Router\Http\Wildcard;
 use Laminas\Stdlib\Request as BaseRequest;
 use LaminasTest\Router\FactoryTester;
@@ -110,7 +110,7 @@ final class WildcardTest extends TestCase
         if ($params === null) {
             $this->assertNull($match);
         } else {
-            $this->assertInstanceOf(RouteMatch::class, $match);
+            $this->assertInstanceOf(HttpRouteMatch::class, $match);
 
             if ($offset === null) {
                 $this->assertEquals(strlen($path), $match->getLength());


### PR DESCRIPTION
- Same logic as #91
- Updated Psalm baseline for new class references and deprecations.