### PR TITLE
 Replace detailed docblocks with `@inheritDoc` where applicable.

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,16 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="6.15.1@28dc127af1b5aecd52314f6f645bafc10d0e11f9">
   <file src="src/Http/Chain.php">
-    <InvalidReturnStatement>
-      <code><![CDATA[new static(
-            $options['routes'],
-            $options['route_plugins'],
-            $options['prototypes']
-        )]]></code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code><![CDATA[Part]]></code>
-    </InvalidReturnType>
+    <DocblockTypeContradiction>
+      <code><![CDATA[is_array($options)]]></code>
+    </DocblockTypeContradiction>
     <MixedArgument>
       <code><![CDATA[$options['child_routes']]]></code>
       <code><![CDATA[$options['prototypes']]]></code>
@@ -187,6 +180,9 @@
     </UnsafeInstantiation>
   </file>
   <file src="src/Http/Part.php">
+    <DocblockTypeContradiction>
+      <code><![CDATA[is_array($options)]]></code>
+    </DocblockTypeContradiction>
     <MixedArgument>
       <code><![CDATA[$options['child_routes']]]></code>
       <code><![CDATA[$options['may_terminate']]]></code>
@@ -321,9 +317,6 @@
     <DocblockTypeContradiction>
       <code><![CDATA[is_array($options)]]></code>
     </DocblockTypeContradiction>
-    <InvalidArgument>
-      <code><![CDATA[$pathOffset]]></code>
-    </InvalidArgument>
     <MixedArgument>
       <code><![CDATA[$key]]></code>
       <code><![CDATA[$levelParts[$level]]]></code>
@@ -576,9 +569,6 @@
     <PossiblyUnusedProperty>
       <code><![CDATA[$priority]]></code>
     </PossiblyUnusedProperty>
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[$this]]></code>
-    </PossiblyUnusedReturnValue>
     <PropertyNotSetInConstructor>
       <code><![CDATA[$baseUrl]]></code>
       <code><![CDATA[$requestUri]]></code>
@@ -589,9 +579,9 @@
     <TooManyArguments>
       <code><![CDATA[match]]></code>
     </TooManyArguments>
-    <UndefinedMethod>
+    <UndefinedInterfaceMethod>
       <code><![CDATA[addPrototypes]]></code>
-    </UndefinedMethod>
+    </UndefinedInterfaceMethod>
   </file>
   <file src="src/Http/Wildcard.php">
     <ArgumentTypeCoercion>
@@ -894,10 +884,6 @@
     <ArgumentTypeCoercion>
       <code><![CDATA[$exceptionName]]></code>
     </ArgumentTypeCoercion>
-    <InvalidArgument>
-      <code><![CDATA[$offset]]></code>
-      <code><![CDATA[$offset]]></code>
-    </InvalidArgument>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$key]]></code>
       <code><![CDATA[$key]]></code>
@@ -925,6 +911,9 @@
     </UnsafeInstantiation>
   </file>
   <file src="test/Http/TreeRouteStackTest.php">
+    <InvalidArgument>
+      <code><![CDATA['bar']]></code>
+    </InvalidArgument>
     <MixedAssignment>
       <code><![CDATA[$routes]]></code>
     </MixedAssignment>

--- a/src/Http/Chain.php
+++ b/src/Http/Chain.php
@@ -7,7 +7,6 @@ namespace Laminas\Router\Http;
 use ArrayObject;
 use Laminas\Router\Exception;
 use Laminas\Router\PriorityList;
-use Laminas\Router\RouteInterface;
 use Laminas\Router\RoutePluginManager;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
@@ -60,13 +59,8 @@ class Chain extends TreeRouteStack implements HttpRouteInterface
     }
 
     /**
-     * factory(): defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::factory()
-     *
-     * @param  mixed $options
+     * @inheritDoc
      * @throws Exception\InvalidArgumentException
-     * @return Part
      */
     public static function factory($options = [])
     {
@@ -103,17 +97,13 @@ class Chain extends TreeRouteStack implements HttpRouteInterface
     }
 
     /**
-     * match(): defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::match()
-     *
-     * @param  int|null $pathOffset
-     * @return RouteMatch|null
+     * @inheritDoc
+     * @param int|null $pathOffset
      */
     public function match(Request $request, $pathOffset = null, array $options = [])
     {
         if (! method_exists($request, 'getUri')) {
-            return;
+            return null;
         }
 
         if ($pathOffset === null) {
@@ -137,7 +127,7 @@ class Chain extends TreeRouteStack implements HttpRouteInterface
             $subMatch = $route->match($request, $pathOffset, $options);
 
             if ($subMatch === null) {
-                return;
+                return null;
             }
 
             $match->merge($subMatch);
@@ -145,18 +135,14 @@ class Chain extends TreeRouteStack implements HttpRouteInterface
         }
 
         if ($mustTerminate && $pathOffset !== $pathLength) {
-            return;
+            return null;
         }
 
         return $match;
     }
 
     /**
-     * assemble(): Defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::assemble()
-     *
-     * @return mixed
+     * @inheritDoc
      */
     public function assemble(array $params = [], array $options = [])
     {
@@ -187,11 +173,7 @@ class Chain extends TreeRouteStack implements HttpRouteInterface
     }
 
     /**
-     * getAssembledParams(): defined by RouteInterface interface.
-     *
-     * @see    HttpRouteInterface::getAssembledParams
-     *
-     * @return array
+     * @inheritDoc
      */
     public function getAssembledParams()
     {

--- a/src/Http/Hostname.php
+++ b/src/Http/Hostname.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Laminas\Router\Http;
 
 use Laminas\Router\Exception;
-use Laminas\Router\RouteInterface;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
 use Laminas\Uri\UriInterface;
@@ -98,12 +97,7 @@ class Hostname implements HttpRouteInterface
     }
 
     /**
-     * factory(): defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::factory()
-     *
-     * @param  iterable $options
-     * @return Hostname
+     * @inheritDoc
      * @throws Exception\InvalidArgumentException
      */
     public static function factory($options = [])
@@ -307,11 +301,7 @@ class Hostname implements HttpRouteInterface
     }
 
     /**
-     * match(): defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::match()
-     *
-     * @return RouteMatch|null
+     * @inheritDoc
      */
     public function match(Request $request)
     {
@@ -341,11 +331,7 @@ class Hostname implements HttpRouteInterface
     }
 
     /**
-     * assemble(): Defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::assemble()
-     *
-     * @return mixed
+     * @inheritDoc
      */
     public function assemble(array $params = [], array $options = [])
     {
@@ -366,11 +352,7 @@ class Hostname implements HttpRouteInterface
     }
 
     /**
-     * getAssembledParams(): defined by HttpRouteInterface interface.
-     *
-     * @see    HttpRouteInterface::getAssembledParams
-     *
-     * @return list<string>
+     * @inheritDoc
      */
     public function getAssembledParams()
     {

--- a/src/Http/Literal.php
+++ b/src/Http/Literal.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Laminas\Router\Http;
 
 use Laminas\Router\Exception;
-use Laminas\Router\RouteInterface;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
 use Traversable;
@@ -52,12 +51,7 @@ class Literal implements HttpRouteInterface
     }
 
     /**
-     * factory(): defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::factory()
-     *
-     * @param  iterable $options
-     * @return Literal
+     * @inheritDoc
      * @throws Exception\InvalidArgumentException
      */
     public static function factory($options = [])
@@ -83,12 +77,8 @@ class Literal implements HttpRouteInterface
     }
 
     /**
-     * match(): defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::match()
-     *
-     * @param  integer|null $pathOffset
-     * @return RouteMatch|null
+     * @inheritDoc
+     * @param int|null $pathOffset
      */
     public function match(Request $request, $pathOffset = null)
     {
@@ -117,11 +107,7 @@ class Literal implements HttpRouteInterface
     }
 
     /**
-     * assemble(): Defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::assemble()
-     *
-     * @return mixed
+     * @inheritDoc
      */
     public function assemble(array $params = [], array $options = [])
     {
@@ -129,11 +115,7 @@ class Literal implements HttpRouteInterface
     }
 
     /**
-     * getAssembledParams(): defined by HttpRouteInterface interface.
-     *
-     * @see    HttpRouteInterface::getAssembledParams
-     *
-     * @return array
+     * @inheritDoc
      */
     public function getAssembledParams()
     {

--- a/src/Http/Method.php
+++ b/src/Http/Method.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Laminas\Router\Http;
 
 use Laminas\Router\Exception;
-use Laminas\Router\RouteInterface;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
 use Traversable;
@@ -54,12 +53,7 @@ class Method implements HttpRouteInterface
     }
 
     /**
-     * factory(): defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::factory()
-     *
-     * @param  iterable $options
-     * @return Method
+     * @inheritDoc
      * @throws Exception\InvalidArgumentException
      */
     public static function factory($options = [])
@@ -85,11 +79,7 @@ class Method implements HttpRouteInterface
     }
 
     /**
-     * match(): defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::match()
-     *
-     * @return RouteMatch|null
+     * @inheritDoc
      */
     public function match(Request $request)
     {
@@ -109,11 +99,7 @@ class Method implements HttpRouteInterface
     }
 
     /**
-     * assemble(): Defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::assemble()
-     *
-     * @return mixed
+     * @inheritDoc
      */
     public function assemble(array $params = [], array $options = [])
     {
@@ -122,11 +108,7 @@ class Method implements HttpRouteInterface
     }
 
     /**
-     * getAssembledParams(): defined by HttpRouteInterface interface.
-     *
-     * @see    HttpRouteInterface::getAssembledParams
-     *
-     * @return array
+     * @inheritDoc
      */
     public function getAssembledParams()
     {

--- a/src/Http/Part.php
+++ b/src/Http/Part.php
@@ -7,7 +7,6 @@ namespace Laminas\Router\Http;
 use ArrayObject;
 use Laminas\Router\Exception;
 use Laminas\Router\PriorityList;
-use Laminas\Router\RouteInterface;
 use Laminas\Router\RoutePluginManager;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
@@ -78,12 +77,7 @@ class Part extends TreeRouteStack implements HttpRouteInterface
     }
 
     /**
-     * factory(): defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::factory()
-     *
-     * @param  mixed $options
-     * @return Part
+     * @inheritDoc
      * @throws Exception\InvalidArgumentException
      */
     public static function factory($options = [])
@@ -131,12 +125,8 @@ class Part extends TreeRouteStack implements HttpRouteInterface
     }
 
     /**
-     * match(): defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::match()
-     *
-     * @param  integer|null $pathOffset
-     * @return RouteMatch|null
+     * @inheritDoc
+     * @param int|null $pathOffset
      */
     public function match(Request $request, $pathOffset = null, array $options = [])
     {
@@ -182,11 +172,7 @@ class Part extends TreeRouteStack implements HttpRouteInterface
     }
 
     /**
-     * assemble(): Defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::assemble()
-     *
-     * @return mixed
+     * @inheritDoc
      * @throws Exception\RuntimeException
      */
     public function assemble(array $params = [], array $options = [])
@@ -219,11 +205,7 @@ class Part extends TreeRouteStack implements HttpRouteInterface
     }
 
     /**
-     * getAssembledParams(): defined by HttpRouteInterface interface.
-     *
-     * @see    HttpRouteInterface::getAssembledParams
-     *
-     * @return array
+     * @inheritDoc
      */
     public function getAssembledParams()
     {

--- a/src/Http/Placeholder.php
+++ b/src/Http/Placeholder.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Laminas\Router\Http;
 
 use Laminas\Router\Exception;
-use Laminas\Router\RouteInterface;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
 use Traversable;
@@ -31,12 +30,7 @@ class Placeholder implements HttpRouteInterface
     }
 
     /**
-     * factory(): defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::factory()
-     *
-     * @param  iterable $options
-     * @return Placeholder
+     * @inheritDoc
      * @throws Exception\InvalidArgumentException
      */
     public static function factory($options = [])
@@ -64,12 +58,8 @@ class Placeholder implements HttpRouteInterface
     }
 
     /**
-     * match(): defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::match()
-     *
-     * @param  integer|null $pathOffset
-     * @return RouteMatch|null
+     * @inheritDoc
+     * @param int|null $pathOffset
      */
     public function match(Request $request, $pathOffset = null)
     {
@@ -77,11 +67,7 @@ class Placeholder implements HttpRouteInterface
     }
 
     /**
-     * assemble(): Defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::assemble()
-     *
-     * @return mixed
+     * @inheritDoc
      */
     public function assemble(array $params = [], array $options = [])
     {
@@ -89,11 +75,7 @@ class Placeholder implements HttpRouteInterface
     }
 
     /**
-     * getAssembledParams(): defined by RouteInterface interface.
-     *
-     * @see    HttpRouteInterface::getAssembledParams
-     *
-     * @return array
+     * @inheritDoc
      */
     public function getAssembledParams()
     {

--- a/src/Http/Regex.php
+++ b/src/Http/Regex.php
@@ -6,7 +6,6 @@ namespace Laminas\Router\Http;
 
 use Laminas\Router\Exception;
 use Laminas\Router\Exception\InvalidArgumentException;
-use Laminas\Router\RouteInterface;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
 use Traversable;
@@ -74,12 +73,7 @@ class Regex implements HttpRouteInterface
     }
 
     /**
-     * factory(): defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::factory()
-     *
-     * @param  iterable $options
-     * @return Regex
+     * @inheritDoc
      * @throws InvalidArgumentException
      */
     public static function factory($options = [])
@@ -109,15 +103,13 @@ class Regex implements HttpRouteInterface
     }
 
     /**
-     * match(): defined by RouteInterface interface.
-     *
-     * @param  int $pathOffset
-     * @return RouteMatch|null
+     * @inheritDoc
+     * @param int|null $pathOffset
      */
     public function match(Request $request, $pathOffset = null)
     {
         if (! method_exists($request, 'getUri')) {
-            return;
+            return null;
         }
 
         $uri  = $request->getUri();
@@ -130,7 +122,7 @@ class Regex implements HttpRouteInterface
         }
 
         if (! $result) {
-            return;
+            return null;
         }
 
         $matchedLength = strlen($matches[0]);
@@ -147,11 +139,7 @@ class Regex implements HttpRouteInterface
     }
 
     /**
-     * assemble(): Defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::assemble()
-     *
-     * @return mixed
+     * @inheritDoc
      */
     public function assemble(array $params = [], array $options = [])
     {
@@ -173,11 +161,7 @@ class Regex implements HttpRouteInterface
     }
 
     /**
-     * getAssembledParams(): defined by HttpRouteInterface interface.
-     *
-     * @see    HttpRouteInterface::getAssembledParams
-     *
-     * @return array
+     * @inheritDoc
      */
     public function getAssembledParams()
     {

--- a/src/Http/RouteMatch.php
+++ b/src/Http/RouteMatch.php
@@ -29,12 +29,7 @@ class RouteMatch extends BaseRouteMatch
     }
 
     /**
-     * setMatchedRouteName(): defined by BaseRouteMatch.
-     *
-     * @see    BaseRouteMatch::setMatchedRouteName()
-     *
-     * @param  string $name
-     * @return RouteMatch
+     * @inheritDoc
      */
     public function setMatchedRouteName($name)
     {

--- a/src/Http/Scheme.php
+++ b/src/Http/Scheme.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Laminas\Router\Http;
 
 use Laminas\Router\Exception;
-use Laminas\Router\RouteInterface;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
 use Traversable;
@@ -50,12 +49,7 @@ class Scheme implements HttpRouteInterface
     }
 
     /**
-     * factory(): defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::factory()
-     *
-     * @param  iterable $options
-     * @return Scheme
+     * @inheritDoc
      * @throws Exception\InvalidArgumentException
      */
     public static function factory($options = [])
@@ -81,34 +75,26 @@ class Scheme implements HttpRouteInterface
     }
 
     /**
-     * match(): defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::match()
-     *
-     * @return RouteMatch|null
+     * @inheritDoc
      */
     public function match(Request $request)
     {
         if (! method_exists($request, 'getUri')) {
-            return;
+            return null;
         }
 
         $uri    = $request->getUri();
         $scheme = $uri->getScheme();
 
         if ($scheme !== $this->scheme) {
-            return;
+            return null;
         }
 
         return new RouteMatch($this->defaults);
     }
 
     /**
-     * assemble(): Defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::assemble()
-     *
-     * @return mixed
+     * @inheritDoc
      */
     public function assemble(array $params = [], array $options = [])
     {
@@ -121,11 +107,7 @@ class Scheme implements HttpRouteInterface
     }
 
     /**
-     * getAssembledParams(): defined by HttpRouteInterface interface.
-     *
-     * @see    HttpRouteInterface::getAssembledParams
-     *
-     * @return array
+     * @inheritDoc
      */
     public function getAssembledParams()
     {

--- a/src/Http/Segment.php
+++ b/src/Http/Segment.php
@@ -6,7 +6,6 @@ namespace Laminas\Router\Http;
 
 use Laminas\I18n\Translator\TranslatorInterface as Translator;
 use Laminas\Router\Exception;
-use Laminas\Router\RouteInterface;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface as Request;
 use Traversable;
@@ -131,12 +130,7 @@ class Segment implements HttpRouteInterface
     }
 
     /**
-     * factory(): defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::factory()
-     *
-     * @param  iterable $options
-     * @return Segment
+     * @inheritDoc
      * @throws Exception\InvalidArgumentException
      */
     public static function factory($options = [])
@@ -363,18 +357,14 @@ class Segment implements HttpRouteInterface
     }
 
     /**
-     * match(): defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::match()
-     *
-     * @param  string|null $pathOffset
-     * @return RouteMatch|null
+     * @inheritDoc
+     * @param int|null $pathOffset
      * @throws Exception\RuntimeException
      */
     public function match(Request $request, $pathOffset = null, array $options = [])
     {
         if (! method_exists($request, 'getUri')) {
-            return;
+            return null;
         }
 
         $uri  = $request->getUri();
@@ -403,7 +393,7 @@ class Segment implements HttpRouteInterface
         }
 
         if (! $result) {
-            return;
+            return null;
         }
 
         $matchedLength = strlen($matches[0]);
@@ -419,11 +409,7 @@ class Segment implements HttpRouteInterface
     }
 
     /**
-     * assemble(): Defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::assemble()
-     *
-     * @return mixed
+     * @inheritDoc
      */
     public function assemble(array $params = [], array $options = [])
     {
@@ -439,11 +425,7 @@ class Segment implements HttpRouteInterface
     }
 
     /**
-     * getAssembledParams(): defined by HttpRouteInterface interface.
-     *
-     * @see    HttpRouteInterface::getAssembledParams
-     *
-     * @return array
+     * @inheritDoc
      */
     public function getAssembledParams()
     {

--- a/src/Http/TranslatorAwareTreeRouteStack.php
+++ b/src/Http/TranslatorAwareTreeRouteStack.php
@@ -7,7 +7,6 @@ namespace Laminas\Router\Http;
 use Laminas\I18n\Translator\TranslatorAwareInterface;
 use Laminas\I18n\Translator\TranslatorInterface as Translator;
 use Laminas\Router\Exception;
-use Laminas\Router\RouteInterface;
 use Laminas\Stdlib\RequestInterface as Request;
 
 /**
@@ -40,12 +39,8 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
     protected $translatorTextDomain = 'default';
 
     /**
-     * match(): defined by RouteInterface
-     *
-     * @see    RouteInterface::match()
-     *
-     * @param  integer|null $pathOffset
-     * @return RouteMatch|null
+     * @inheritDoc
+     * @param int|null $pathOffset
      */
     public function match(Request $request, $pathOffset = null, array $options = [])
     {
@@ -61,11 +56,7 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
     }
 
     /**
-     * assemble(): defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::assemble()
-     *
-     * @return mixed
+     * @inheritDoc
      * @throws Exception\InvalidArgumentException
      * @throws Exception\RuntimeException
      */

--- a/src/Http/TreeRouteStack.php
+++ b/src/Http/TreeRouteStack.php
@@ -6,7 +6,6 @@ namespace Laminas\Router\Http;
 
 use ArrayObject;
 use Laminas\Router\Exception;
-use Laminas\Router\RouteInterface;
 use Laminas\Router\RouteInvokableFactory;
 use Laminas\Router\SimpleRouteStack;
 use Laminas\ServiceManager\Config;
@@ -65,12 +64,7 @@ class TreeRouteStack extends SimpleRouteStack
     public $priority;
 
     /**
-     * factory(): defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::factory()
-     *
-     * @param  iterable $options
-     * @return SimpleRouteStack
+     * @inheritDoc
      * @throws Exception\InvalidArgumentException
      */
     public static function factory($options = [])
@@ -96,9 +90,7 @@ class TreeRouteStack extends SimpleRouteStack
     }
 
     /**
-     * init(): defined by SimpleRouteStack.
-     *
-     * @see    SimpleRouteStack::init()
+     * @inheritDoc
      */
     protected function init()
     {
@@ -156,12 +148,7 @@ class TreeRouteStack extends SimpleRouteStack
     }
 
     /**
-     * addRoute(): defined by RouteStackInterface interface.
-     *
-     * @param string                 $name
-     * @param string|iterable|TRoute $route
-     * @param int                    $priority
-     * @return $this
+     * @inheritDoc
      */
     public function addRoute($name, $route, $priority = null)
     {
@@ -289,12 +276,8 @@ class TreeRouteStack extends SimpleRouteStack
     }
 
     /**
-     * match(): defined by RouteInterface
-     *
-     * @see    RouteInterface::match()
-     *
-     * @param  int|null $pathOffset
-     * @return RouteMatch|null
+     * @inheritDoc
+     * @param int|null $pathOffset
      */
     public function match(Request $request, $pathOffset = null, array $options = [])
     {
@@ -344,11 +327,7 @@ class TreeRouteStack extends SimpleRouteStack
     }
 
     /**
-     * assemble(): defined by RouteInterface interface.
-     *
-     * @see    RouteInterface::assemble()
-     *
-     * @return mixed
+     * @inheritDoc
      * @throws Exception\InvalidArgumentException
      * @throws Exception\RuntimeException
      */

--- a/src/SimpleRouteStack.php
+++ b/src/SimpleRouteStack.php
@@ -56,12 +56,7 @@ class SimpleRouteStack implements RouteStackInterface
     }
 
     /**
-     * factory(): defined by RouteInterface interface.
-     *
-     * @see    \Laminas\Router\RouteInterface::factory()
-     *
-     * @param  iterable $options
-     * @return SimpleRouteStack
+     * @inheritDoc
      * @throws Exception\InvalidArgumentException
      */
     public static function factory($options = [])
@@ -258,11 +253,7 @@ class SimpleRouteStack implements RouteStackInterface
     }
 
     /**
-     * match(): defined by RouteInterface interface.
-     *
-     * @see    \Laminas\Router\RouteInterface::match()
-     *
-     * @return RouteMatch|null
+     * @inheritDoc
      */
     public function match(Request $request)
     {
@@ -284,11 +275,7 @@ class SimpleRouteStack implements RouteStackInterface
     }
 
     /**
-     * assemble(): defined by RouteInterface interface.
-     *
-     * @see    \Laminas\Router\RouteInterface::assemble()
-     *
-     * @return mixed
+     * @inheritDoc
      * @throws Exception\InvalidArgumentException
      * @throws Exception\RuntimeException
      */


### PR DESCRIPTION
- Update Psalm baseline to reflect changes.
- correct return; by return null;

need #101