### PR TITLE
Add soft `@final` to classes signalling move to `final` keyword in the next major release

### DIFF
--- a/docs/book/routing.md
+++ b/docs/book/routing.md
@@ -14,12 +14,12 @@ The base unit of routing is a `Route`:
 ```php
 namespace Laminas\Router;
 
-use Laminas\Stdlib\RequestInterface as Request;
+use Laminas\Stdlib\RequestInterface;
 
 interface RouteInterface
 {
     public static function factory(array $options = []);
-    public function match(Request $request);
+    public function match(RequestInterface $request);
     public function assemble(array $params = [], array $options = []);
 }
 ```

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -36,13 +36,6 @@
     <TooManyArguments>
       <code><![CDATA[match]]></code>
     </TooManyArguments>
-    <UnsafeInstantiation>
-      <code><![CDATA[new static(
-            $options['routes'],
-            $options['route_plugins'],
-            $options['prototypes']
-        )]]></code>
-    </UnsafeInstantiation>
   </file>
   <file src="src/Http/Hostname.php">
     <ArgumentTypeCoercion>
@@ -112,9 +105,6 @@
     <PossiblyUnusedProperty>
       <code><![CDATA[$priority]]></code>
     </PossiblyUnusedProperty>
-    <UnsafeInstantiation>
-      <code><![CDATA[new static($options['route'], $options['constraints'], $options['defaults'])]]></code>
-    </UnsafeInstantiation>
     <UnsupportedReferenceUsage>
       <code><![CDATA[$levelParts[$level + 1] = &$levelParts[$level][count($levelParts[$level]) - 1][1]]]></code>
     </UnsupportedReferenceUsage>
@@ -159,9 +149,6 @@
     <PossiblyUnusedProperty>
       <code><![CDATA[$priority]]></code>
     </PossiblyUnusedProperty>
-    <UnsafeInstantiation>
-      <code><![CDATA[new static($options['route'], $options['defaults'])]]></code>
-    </UnsafeInstantiation>
   </file>
   <file src="src/Http/Method.php">
     <DocblockTypeContradiction>
@@ -175,9 +162,6 @@
     <PossiblyUnusedProperty>
       <code><![CDATA[$priority]]></code>
     </PossiblyUnusedProperty>
-    <UnsafeInstantiation>
-      <code><![CDATA[new static($options['verb'], $options['defaults'])]]></code>
-    </UnsafeInstantiation>
   </file>
   <file src="src/Http/Part.php">
     <DocblockTypeContradiction>
@@ -226,15 +210,6 @@
       <code><![CDATA[match]]></code>
       <code><![CDATA[match]]></code>
     </TooManyArguments>
-    <UnsafeInstantiation>
-      <code><![CDATA[new static(
-            $options['route'],
-            $options['may_terminate'],
-            $options['route_plugins'],
-            $options['child_routes'],
-            $options['prototypes']
-        )]]></code>
-    </UnsafeInstantiation>
   </file>
   <file src="src/Http/Placeholder.php">
     <DocblockTypeContradiction>
@@ -243,9 +218,6 @@
     <PossiblyUnusedProperty>
       <code><![CDATA[$priority]]></code>
     </PossiblyUnusedProperty>
-    <UnsafeInstantiation>
-      <code><![CDATA[new static($options['defaults'])]]></code>
-    </UnsafeInstantiation>
   </file>
   <file src="src/Http/Regex.php">
     <DocblockTypeContradiction>
@@ -273,9 +245,6 @@
       <code><![CDATA[is_int($key)]]></code>
       <code><![CDATA[is_numeric($key) || is_int($key)]]></code>
     </TypeDoesNotContainType>
-    <UnsafeInstantiation>
-      <code><![CDATA[new static($options['regex'], $options['spec'], $options['defaults'])]]></code>
-    </UnsafeInstantiation>
   </file>
   <file src="src/Http/RouteInterface.php">
     <UnusedClass>
@@ -309,9 +278,6 @@
     <PossiblyUnusedProperty>
       <code><![CDATA[$priority]]></code>
     </PossiblyUnusedProperty>
-    <UnsafeInstantiation>
-      <code><![CDATA[new static($options['scheme'], $options['defaults'])]]></code>
-    </UnsafeInstantiation>
   </file>
   <file src="src/Http/Segment.php">
     <DocblockTypeContradiction>
@@ -413,9 +379,6 @@
     <PossiblyUnusedProperty>
       <code><![CDATA[$priority]]></code>
     </PossiblyUnusedProperty>
-    <UnsafeInstantiation>
-      <code><![CDATA[new static($options['route'], $options['constraints'], $options['defaults'])]]></code>
-    </UnsafeInstantiation>
     <UnsupportedReferenceUsage>
       <code><![CDATA[$levelParts[$level + 1] = &$levelParts[$level][count($levelParts[$level]) - 1][1]]]></code>
     </UnsupportedReferenceUsage>
@@ -429,7 +392,6 @@
     <LessSpecificImplementedReturnType>
       <code><![CDATA[TreeRouteStack]]></code>
       <code><![CDATA[TreeRouteStack]]></code>
-      <code><![CDATA[self]]></code>
     </LessSpecificImplementedReturnType>
     <PossiblyNullPropertyAssignmentValue>
       <code><![CDATA[$translator]]></code>
@@ -910,6 +872,12 @@
       <code><![CDATA[new static()]]></code>
     </UnsafeInstantiation>
   </file>
+  <file src="test/Http/TranslatorAwareTreeRouteStackTest.php">
+    <DocblockTypeContradiction>
+      <code><![CDATA[assertNull]]></code>
+      <code><![CDATA[assertNull]]></code>
+    </DocblockTypeContradiction>
+  </file>
   <file src="test/Http/TreeRouteStackTest.php">
     <InvalidArgument>
       <code><![CDATA['bar']]></code>
@@ -1054,6 +1022,9 @@
     </UndefinedClass>
   </file>
   <file src="test/PriorityListTest.php">
+    <InternalClass>
+      <code><![CDATA[new PriorityList()]]></code>
+    </InternalClass>
     <InvalidArgument>
       <code><![CDATA[$list]]></code>
       <code><![CDATA[$list]]></code>
@@ -1069,6 +1040,14 @@
     <DeprecatedMethod>
       <code><![CDATA[createService]]></code>
     </DeprecatedMethod>
+    <InternalClass>
+      <code><![CDATA[new RoutePluginManagerFactory()]]></code>
+    </InternalClass>
+    <InternalMethod>
+      <code><![CDATA[__invoke]]></code>
+      <code><![CDATA[__invoke]]></code>
+      <code><![CDATA[createService]]></code>
+    </InternalMethod>
     <MissingClosureParamType>
       <code><![CDATA[$container]]></code>
     </MissingClosureParamType>
@@ -1097,6 +1076,13 @@
             ],
         ]))]]></code>
     </DeprecatedClass>
+    <InternalClass>
+      <code><![CDATA[new RouterFactory()]]></code>
+    </InternalClass>
+    <InternalMethod>
+      <code><![CDATA[__invoke]]></code>
+      <code><![CDATA[__invoke]]></code>
+    </InternalMethod>
     <MissingClosureParamType>
       <code><![CDATA[$services]]></code>
     </MissingClosureParamType>

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -17,6 +17,7 @@ use Laminas\ServiceManager\ConfigInterface;
  * @see ConfigInterface
  *
  * @psalm-import-type ServiceManagerConfigurationType from ConfigInterface
+ * @final
  */
 class ConfigProvider
 {

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Router\Exception;
 
+/**
+ * @final
+ */
 class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
 {
 }

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Router\Exception;
 
+/**
+ * @final
+ */
 class RuntimeException extends \RuntimeException implements ExceptionInterface
 {
 }

--- a/src/Http/Chain.php
+++ b/src/Http/Chain.php
@@ -9,7 +9,7 @@ use Laminas\Router\Exception;
 use Laminas\Router\PriorityList;
 use Laminas\Router\RoutePluginManager;
 use Laminas\Stdlib\ArrayUtils;
-use Laminas\Stdlib\RequestInterface as Request;
+use Laminas\Stdlib\RequestInterface;
 use Traversable;
 
 use function array_diff_key;
@@ -100,7 +100,7 @@ class Chain extends TreeRouteStack implements HttpRouteInterface
      * @inheritDoc
      * @param int|null $pathOffset
      */
-    public function match(Request $request, $pathOffset = null, array $options = [])
+    public function match(RequestInterface $request, $pathOffset = null, array $options = [])
     {
         if (! method_exists($request, 'getUri')) {
             return null;

--- a/src/Http/Chain.php
+++ b/src/Http/Chain.php
@@ -10,6 +10,7 @@ use Laminas\Router\PriorityList;
 use Laminas\Router\RoutePluginManager;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface;
+use Override;
 use Traversable;
 
 use function array_diff_key;
@@ -63,6 +64,7 @@ class Chain extends TreeRouteStack implements HttpRouteInterface
      * @inheritDoc
      * @throws Exception\InvalidArgumentException
      */
+    #[Override]
     public static function factory($options = [])
     {
         if ($options instanceof Traversable) {
@@ -101,6 +103,7 @@ class Chain extends TreeRouteStack implements HttpRouteInterface
      * @inheritDoc
      * @param int|null $pathOffset
      */
+    #[Override]
     public function match(RequestInterface $request, $pathOffset = null, array $options = [])
     {
         if (! method_exists($request, 'getUri')) {
@@ -145,6 +148,7 @@ class Chain extends TreeRouteStack implements HttpRouteInterface
     /**
      * @inheritDoc
      */
+    #[Override]
     public function assemble(array $params = [], array $options = [])
     {
         if ($this->chainRoutes !== null) {
@@ -176,6 +180,7 @@ class Chain extends TreeRouteStack implements HttpRouteInterface
     /**
      * @inheritDoc
      */
+    #[Override]
     public function getAssembledParams()
     {
         return $this->assembledParams;

--- a/src/Http/Chain.php
+++ b/src/Http/Chain.php
@@ -26,6 +26,7 @@ use function strlen;
 /**
  * @template TRoute of HttpRouteInterface
  * @template-extends TreeRouteStack<TRoute>
+ * @final
  */
 class Chain extends TreeRouteStack implements HttpRouteInterface
 {

--- a/src/Http/Hostname.php
+++ b/src/Http/Hostname.php
@@ -8,6 +8,7 @@ use Laminas\Router\Exception;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface;
 use Laminas\Uri\UriInterface;
+use Override;
 use Traversable;
 
 use function array_merge;
@@ -101,6 +102,7 @@ class Hostname implements HttpRouteInterface
      * @inheritDoc
      * @throws Exception\InvalidArgumentException
      */
+    #[Override]
     public static function factory($options = [])
     {
         if ($options instanceof Traversable) {
@@ -304,6 +306,7 @@ class Hostname implements HttpRouteInterface
     /**
      * @inheritDoc
      */
+    #[Override]
     public function match(RequestInterface $request)
     {
         if (! method_exists($request, 'getUri')) {
@@ -334,6 +337,7 @@ class Hostname implements HttpRouteInterface
     /**
      * @inheritDoc
      */
+    #[Override]
     public function assemble(array $params = [], array $options = [])
     {
         $this->assembledParams = [];
@@ -355,6 +359,7 @@ class Hostname implements HttpRouteInterface
     /**
      * @inheritDoc
      */
+    #[Override]
     public function getAssembledParams()
     {
         return $this->assembledParams;

--- a/src/Http/Hostname.php
+++ b/src/Http/Hostname.php
@@ -38,6 +38,7 @@ use function strlen;
  *      list<array{'literal', string, string|null}|array{'parameter', string}|array{'optional', array}>
  *     }
  * >
+ * @final
  */
 class Hostname implements HttpRouteInterface
 {

--- a/src/Http/Hostname.php
+++ b/src/Http/Hostname.php
@@ -6,7 +6,7 @@ namespace Laminas\Router\Http;
 
 use Laminas\Router\Exception;
 use Laminas\Stdlib\ArrayUtils;
-use Laminas\Stdlib\RequestInterface as Request;
+use Laminas\Stdlib\RequestInterface;
 use Laminas\Uri\UriInterface;
 use Traversable;
 
@@ -303,7 +303,7 @@ class Hostname implements HttpRouteInterface
     /**
      * @inheritDoc
      */
-    public function match(Request $request)
+    public function match(RequestInterface $request)
     {
         if (! method_exists($request, 'getUri')) {
             return null;

--- a/src/Http/HttpRouteInterface.php
+++ b/src/Http/HttpRouteInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Router\Http;
 
 use Laminas\Router\RouteInterface;
-use Laminas\Stdlib\RequestInterface as Request;
+use Laminas\Stdlib\RequestInterface;
 
 /**
  * Tree specific route interface.
@@ -13,7 +13,7 @@ use Laminas\Stdlib\RequestInterface as Request;
  * Note: the additional {@see self::match()} annotation is only here for documentation purposes, because we cannot
  *       change the signature of {@see self::match()} in the interface definition without breaking BC.
  *
- * @method RouteMatch|null match(Request $request, int|null $pathOffset = null, array $options = [])
+ * @method RouteMatch|null match(RequestInterface $request, int|null $pathOffset = null, array $options = [])
  */
 interface HttpRouteInterface extends RouteInterface
 {

--- a/src/Http/HttpRouterFactory.php
+++ b/src/Http/HttpRouterFactory.php
@@ -10,6 +10,9 @@ use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Psr\Container\ContainerInterface;
 
+/**
+ * @final
+ */
 class HttpRouterFactory implements FactoryInterface
 {
     use RouterConfigTrait;

--- a/src/Http/Literal.php
+++ b/src/Http/Literal.php
@@ -7,6 +7,7 @@ namespace Laminas\Router\Http;
 use Laminas\Router\Exception;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface;
+use Override;
 use Traversable;
 
 use function is_array;
@@ -56,6 +57,7 @@ class Literal implements HttpRouteInterface
      * @inheritDoc
      * @throws Exception\InvalidArgumentException
      */
+    #[Override]
     public static function factory($options = [])
     {
         if ($options instanceof Traversable) {
@@ -82,6 +84,7 @@ class Literal implements HttpRouteInterface
      * @inheritDoc
      * @param int|null $pathOffset
      */
+    #[Override]
     public function match(RequestInterface $request, $pathOffset = null)
     {
         if (! method_exists($request, 'getUri')) {
@@ -111,6 +114,7 @@ class Literal implements HttpRouteInterface
     /**
      * @inheritDoc
      */
+    #[Override]
     public function assemble(array $params = [], array $options = [])
     {
         return $this->route;
@@ -119,6 +123,7 @@ class Literal implements HttpRouteInterface
     /**
      * @inheritDoc
      */
+    #[Override]
     public function getAssembledParams()
     {
         return [];

--- a/src/Http/Literal.php
+++ b/src/Http/Literal.php
@@ -6,7 +6,7 @@ namespace Laminas\Router\Http;
 
 use Laminas\Router\Exception;
 use Laminas\Stdlib\ArrayUtils;
-use Laminas\Stdlib\RequestInterface as Request;
+use Laminas\Stdlib\RequestInterface;
 use Traversable;
 
 use function is_array;
@@ -80,7 +80,7 @@ class Literal implements HttpRouteInterface
      * @inheritDoc
      * @param int|null $pathOffset
      */
-    public function match(Request $request, $pathOffset = null)
+    public function match(RequestInterface $request, $pathOffset = null)
     {
         if (! method_exists($request, 'getUri')) {
             return null;

--- a/src/Http/Literal.php
+++ b/src/Http/Literal.php
@@ -17,6 +17,8 @@ use function strpos;
 
 /**
  * Literal route.
+ *
+ * @final
  */
 class Literal implements HttpRouteInterface
 {

--- a/src/Http/Method.php
+++ b/src/Http/Method.php
@@ -6,7 +6,7 @@ namespace Laminas\Router\Http;
 
 use Laminas\Router\Exception;
 use Laminas\Stdlib\ArrayUtils;
-use Laminas\Stdlib\RequestInterface as Request;
+use Laminas\Stdlib\RequestInterface;
 use Traversable;
 
 use function array_map;
@@ -81,7 +81,7 @@ class Method implements HttpRouteInterface
     /**
      * @inheritDoc
      */
-    public function match(Request $request)
+    public function match(RequestInterface $request)
     {
         if (! method_exists($request, 'getMethod')) {
             return null;

--- a/src/Http/Method.php
+++ b/src/Http/Method.php
@@ -19,6 +19,8 @@ use function strtoupper;
 
 /**
  * Method route.
+ *
+ * @final
  */
 class Method implements HttpRouteInterface
 {

--- a/src/Http/Method.php
+++ b/src/Http/Method.php
@@ -7,6 +7,7 @@ namespace Laminas\Router\Http;
 use Laminas\Router\Exception;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface;
+use Override;
 use Traversable;
 
 use function array_map;
@@ -58,6 +59,7 @@ class Method implements HttpRouteInterface
      * @inheritDoc
      * @throws Exception\InvalidArgumentException
      */
+    #[Override]
     public static function factory($options = [])
     {
         if ($options instanceof Traversable) {
@@ -83,6 +85,7 @@ class Method implements HttpRouteInterface
     /**
      * @inheritDoc
      */
+    #[Override]
     public function match(RequestInterface $request)
     {
         if (! method_exists($request, 'getMethod')) {
@@ -103,6 +106,7 @@ class Method implements HttpRouteInterface
     /**
      * @inheritDoc
      */
+    #[Override]
     public function assemble(array $params = [], array $options = [])
     {
         // The request method does not contribute to the path, thus nothing is returned.
@@ -112,6 +116,7 @@ class Method implements HttpRouteInterface
     /**
      * @inheritDoc
      */
+    #[Override]
     public function getAssembledParams()
     {
         return [];

--- a/src/Http/Part.php
+++ b/src/Http/Part.php
@@ -22,6 +22,7 @@ use function strlen;
 /**
  * @template TRoute of HttpRouteInterface
  * @template-extends TreeRouteStack<TRoute>
+ * @final
  */
 class Part extends TreeRouteStack implements HttpRouteInterface
 {

--- a/src/Http/Part.php
+++ b/src/Http/Part.php
@@ -10,6 +10,7 @@ use Laminas\Router\PriorityList;
 use Laminas\Router\RoutePluginManager;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface;
+use Override;
 use Traversable;
 
 use function array_diff_key;
@@ -81,6 +82,7 @@ class Part extends TreeRouteStack implements HttpRouteInterface
      * @inheritDoc
      * @throws Exception\InvalidArgumentException
      */
+    #[Override]
     public static function factory($options = [])
     {
         if ($options instanceof Traversable) {
@@ -129,6 +131,7 @@ class Part extends TreeRouteStack implements HttpRouteInterface
      * @inheritDoc
      * @param int|null $pathOffset
      */
+    #[Override]
     public function match(RequestInterface $request, $pathOffset = null, array $options = [])
     {
         if ($pathOffset === null) {
@@ -176,6 +179,7 @@ class Part extends TreeRouteStack implements HttpRouteInterface
      * @inheritDoc
      * @throws Exception\RuntimeException
      */
+    #[Override]
     public function assemble(array $params = [], array $options = [])
     {
         if ($this->childRoutes !== null) {
@@ -208,6 +212,7 @@ class Part extends TreeRouteStack implements HttpRouteInterface
     /**
      * @inheritDoc
      */
+    #[Override]
     public function getAssembledParams()
     {
         // Part routes may not occur as base route of other part routes, so we

--- a/src/Http/Part.php
+++ b/src/Http/Part.php
@@ -9,7 +9,7 @@ use Laminas\Router\Exception;
 use Laminas\Router\PriorityList;
 use Laminas\Router\RoutePluginManager;
 use Laminas\Stdlib\ArrayUtils;
-use Laminas\Stdlib\RequestInterface as Request;
+use Laminas\Stdlib\RequestInterface;
 use Traversable;
 
 use function array_diff_key;
@@ -128,7 +128,7 @@ class Part extends TreeRouteStack implements HttpRouteInterface
      * @inheritDoc
      * @param int|null $pathOffset
      */
-    public function match(Request $request, $pathOffset = null, array $options = [])
+    public function match(RequestInterface $request, $pathOffset = null, array $options = [])
     {
         if ($pathOffset === null) {
             $pathOffset = 0;

--- a/src/Http/Placeholder.php
+++ b/src/Http/Placeholder.php
@@ -14,6 +14,8 @@ use function sprintf;
 
 /**
  * Placeholder route.
+ *
+ * @final
  */
 class Placeholder implements HttpRouteInterface
 {

--- a/src/Http/Placeholder.php
+++ b/src/Http/Placeholder.php
@@ -7,6 +7,7 @@ namespace Laminas\Router\Http;
 use Laminas\Router\Exception;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface;
+use Override;
 use Traversable;
 
 use function is_array;
@@ -35,6 +36,7 @@ class Placeholder implements HttpRouteInterface
      * @inheritDoc
      * @throws Exception\InvalidArgumentException
      */
+    #[Override]
     public static function factory($options = [])
     {
         if ($options instanceof Traversable) {
@@ -63,6 +65,7 @@ class Placeholder implements HttpRouteInterface
      * @inheritDoc
      * @param int|null $pathOffset
      */
+    #[Override]
     public function match(RequestInterface $request, $pathOffset = null)
     {
         return new RouteMatch($this->defaults);
@@ -71,6 +74,7 @@ class Placeholder implements HttpRouteInterface
     /**
      * @inheritDoc
      */
+    #[Override]
     public function assemble(array $params = [], array $options = [])
     {
         return '';
@@ -79,6 +83,7 @@ class Placeholder implements HttpRouteInterface
     /**
      * @inheritDoc
      */
+    #[Override]
     public function getAssembledParams()
     {
         return [];

--- a/src/Http/Placeholder.php
+++ b/src/Http/Placeholder.php
@@ -6,7 +6,7 @@ namespace Laminas\Router\Http;
 
 use Laminas\Router\Exception;
 use Laminas\Stdlib\ArrayUtils;
-use Laminas\Stdlib\RequestInterface as Request;
+use Laminas\Stdlib\RequestInterface;
 use Traversable;
 
 use function is_array;
@@ -61,7 +61,7 @@ class Placeholder implements HttpRouteInterface
      * @inheritDoc
      * @param int|null $pathOffset
      */
-    public function match(Request $request, $pathOffset = null)
+    public function match(RequestInterface $request, $pathOffset = null)
     {
         return new RouteMatch($this->defaults);
     }

--- a/src/Http/Regex.php
+++ b/src/Http/Regex.php
@@ -8,6 +8,7 @@ use Laminas\Router\Exception;
 use Laminas\Router\Exception\InvalidArgumentException;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface;
+use Override;
 use Traversable;
 
 use function array_merge;
@@ -78,6 +79,7 @@ class Regex implements HttpRouteInterface
      * @inheritDoc
      * @throws InvalidArgumentException
      */
+    #[Override]
     public static function factory($options = [])
     {
         if ($options instanceof Traversable) {
@@ -108,6 +110,7 @@ class Regex implements HttpRouteInterface
      * @inheritDoc
      * @param int|null $pathOffset
      */
+    #[Override]
     public function match(RequestInterface $request, $pathOffset = null)
     {
         if (! method_exists($request, 'getUri')) {
@@ -143,6 +146,7 @@ class Regex implements HttpRouteInterface
     /**
      * @inheritDoc
      */
+    #[Override]
     public function assemble(array $params = [], array $options = [])
     {
         $url                   = $this->spec;
@@ -165,6 +169,7 @@ class Regex implements HttpRouteInterface
     /**
      * @inheritDoc
      */
+    #[Override]
     public function getAssembledParams()
     {
         return $this->assembledParams;

--- a/src/Http/Regex.php
+++ b/src/Http/Regex.php
@@ -25,6 +25,8 @@ use function strlen;
 
 /**
  * Regex route.
+ *
+ * @final
  */
 class Regex implements HttpRouteInterface
 {

--- a/src/Http/Regex.php
+++ b/src/Http/Regex.php
@@ -7,7 +7,7 @@ namespace Laminas\Router\Http;
 use Laminas\Router\Exception;
 use Laminas\Router\Exception\InvalidArgumentException;
 use Laminas\Stdlib\ArrayUtils;
-use Laminas\Stdlib\RequestInterface as Request;
+use Laminas\Stdlib\RequestInterface;
 use Traversable;
 
 use function array_merge;
@@ -106,7 +106,7 @@ class Regex implements HttpRouteInterface
      * @inheritDoc
      * @param int|null $pathOffset
      */
-    public function match(Request $request, $pathOffset = null)
+    public function match(RequestInterface $request, $pathOffset = null)
     {
         if (! method_exists($request, 'getUri')) {
             return null;

--- a/src/Http/RouteMatch.php
+++ b/src/Http/RouteMatch.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Router\Http;
 
 use Laminas\Router\RouteMatch as BaseRouteMatch;
+use Override;
 
 use function array_merge;
 
@@ -31,6 +32,7 @@ class RouteMatch extends BaseRouteMatch
     /**
      * @inheritDoc
      */
+    #[Override]
     public function setMatchedRouteName($name)
     {
         if ($this->matchedRouteName === null) {

--- a/src/Http/Scheme.php
+++ b/src/Http/Scheme.php
@@ -7,6 +7,7 @@ namespace Laminas\Router\Http;
 use Laminas\Router\Exception;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface;
+use Override;
 use Traversable;
 
 use function is_array;
@@ -54,6 +55,7 @@ class Scheme implements HttpRouteInterface
      * @inheritDoc
      * @throws Exception\InvalidArgumentException
      */
+    #[Override]
     public static function factory($options = [])
     {
         if ($options instanceof Traversable) {
@@ -79,6 +81,7 @@ class Scheme implements HttpRouteInterface
     /**
      * @inheritDoc
      */
+    #[Override]
     public function match(RequestInterface $request)
     {
         if (! method_exists($request, 'getUri')) {
@@ -98,6 +101,7 @@ class Scheme implements HttpRouteInterface
     /**
      * @inheritDoc
      */
+    #[Override]
     public function assemble(array $params = [], array $options = [])
     {
         if (isset($options['uri'])) {
@@ -111,6 +115,7 @@ class Scheme implements HttpRouteInterface
     /**
      * @inheritDoc
      */
+    #[Override]
     public function getAssembledParams()
     {
         return [];

--- a/src/Http/Scheme.php
+++ b/src/Http/Scheme.php
@@ -15,6 +15,8 @@ use function sprintf;
 
 /**
  * Scheme route.
+ *
+ * @final
  */
 class Scheme implements HttpRouteInterface
 {

--- a/src/Http/Scheme.php
+++ b/src/Http/Scheme.php
@@ -6,7 +6,7 @@ namespace Laminas\Router\Http;
 
 use Laminas\Router\Exception;
 use Laminas\Stdlib\ArrayUtils;
-use Laminas\Stdlib\RequestInterface as Request;
+use Laminas\Stdlib\RequestInterface;
 use Traversable;
 
 use function is_array;
@@ -77,7 +77,7 @@ class Scheme implements HttpRouteInterface
     /**
      * @inheritDoc
      */
-    public function match(Request $request)
+    public function match(RequestInterface $request)
     {
         if (! method_exists($request, 'getUri')) {
             return null;

--- a/src/Http/Segment.php
+++ b/src/Http/Segment.php
@@ -8,6 +8,7 @@ use Laminas\I18n\Translator\TranslatorInterface as Translator;
 use Laminas\Router\Exception;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface;
+use Override;
 use Traversable;
 
 use function array_merge;
@@ -135,6 +136,7 @@ class Segment implements HttpRouteInterface
      * @inheritDoc
      * @throws Exception\InvalidArgumentException
      */
+    #[Override]
     public static function factory($options = [])
     {
         if ($options instanceof Traversable) {
@@ -363,6 +365,7 @@ class Segment implements HttpRouteInterface
      * @param int|null $pathOffset
      * @throws Exception\RuntimeException
      */
+    #[Override]
     public function match(RequestInterface $request, $pathOffset = null, array $options = [])
     {
         if (! method_exists($request, 'getUri')) {
@@ -413,6 +416,7 @@ class Segment implements HttpRouteInterface
     /**
      * @inheritDoc
      */
+    #[Override]
     public function assemble(array $params = [], array $options = [])
     {
         $this->assembledParams = [];
@@ -429,6 +433,7 @@ class Segment implements HttpRouteInterface
     /**
      * @inheritDoc
      */
+    #[Override]
     public function getAssembledParams()
     {
         return $this->assembledParams;

--- a/src/Http/Segment.php
+++ b/src/Http/Segment.php
@@ -7,7 +7,7 @@ namespace Laminas\Router\Http;
 use Laminas\I18n\Translator\TranslatorInterface as Translator;
 use Laminas\Router\Exception;
 use Laminas\Stdlib\ArrayUtils;
-use Laminas\Stdlib\RequestInterface as Request;
+use Laminas\Stdlib\RequestInterface;
 use Traversable;
 
 use function array_merge;
@@ -361,7 +361,7 @@ class Segment implements HttpRouteInterface
      * @param int|null $pathOffset
      * @throws Exception\RuntimeException
      */
-    public function match(Request $request, $pathOffset = null, array $options = [])
+    public function match(RequestInterface $request, $pathOffset = null, array $options = [])
     {
         if (! method_exists($request, 'getUri')) {
             return null;

--- a/src/Http/Segment.php
+++ b/src/Http/Segment.php
@@ -25,6 +25,8 @@ use function strtr;
 
 /**
  * Segment route.
+ *
+ * @final
  */
 class Segment implements HttpRouteInterface
 {

--- a/src/Http/TranslatorAwareTreeRouteStack.php
+++ b/src/Http/TranslatorAwareTreeRouteStack.php
@@ -14,6 +14,7 @@ use Laminas\Stdlib\RequestInterface;
  *
  * @template TRoute of HttpRouteInterface
  * @template-extends TreeRouteStack<TRoute>
+ * @final
  */
 class TranslatorAwareTreeRouteStack extends TreeRouteStack implements TranslatorAwareInterface
 {

--- a/src/Http/TranslatorAwareTreeRouteStack.php
+++ b/src/Http/TranslatorAwareTreeRouteStack.php
@@ -8,6 +8,7 @@ use Laminas\I18n\Translator\TranslatorAwareInterface;
 use Laminas\I18n\Translator\TranslatorInterface as Translator;
 use Laminas\Router\Exception;
 use Laminas\Stdlib\RequestInterface;
+use Override;
 
 /**
  * Translator aware tree route stack.
@@ -43,6 +44,7 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
      * @inheritDoc
      * @param int|null $pathOffset
      */
+    #[Override]
     public function match(RequestInterface $request, $pathOffset = null, array $options = [])
     {
         if ($this->hasTranslator() && $this->isTranslatorEnabled() && ! isset($options['translator'])) {
@@ -61,6 +63,7 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
      * @throws Exception\InvalidArgumentException
      * @throws Exception\RuntimeException
      */
+    #[Override]
     public function assemble(array $params = [], array $options = [])
     {
         if ($this->hasTranslator() && $this->isTranslatorEnabled() && ! isset($options['translator'])) {
@@ -82,6 +85,7 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
      * @param  string     $textDomain
      * @return TreeRouteStack
      */
+    #[Override]
     public function setTranslator(?Translator $translator = null, $textDomain = null)
     {
         $this->translator = $translator;
@@ -100,6 +104,7 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
      *
      * @return Translator
      */
+    #[Override]
     public function getTranslator()
     {
         return $this->translator;
@@ -112,6 +117,7 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
      *
      * @return bool
      */
+    #[Override]
     public function hasTranslator()
     {
         return $this->translator !== null;
@@ -125,6 +131,7 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
      * @param  bool $enabled
      * @return TreeRouteStack
      */
+    #[Override]
     public function setTranslatorEnabled($enabled = true)
     {
         $this->translatorEnabled = $enabled;
@@ -138,6 +145,7 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
      *
      * @return bool
      */
+    #[Override]
     public function isTranslatorEnabled()
     {
         return $this->translatorEnabled;
@@ -151,6 +159,7 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
      * @param  string $textDomain
      * @return self
      */
+    #[Override]
     public function setTranslatorTextDomain($textDomain = 'default')
     {
         $this->translatorTextDomain = $textDomain;
@@ -165,6 +174,7 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
      *
      * @return string
      */
+    #[Override]
     public function getTranslatorTextDomain()
     {
         return $this->translatorTextDomain;

--- a/src/Http/TranslatorAwareTreeRouteStack.php
+++ b/src/Http/TranslatorAwareTreeRouteStack.php
@@ -7,7 +7,7 @@ namespace Laminas\Router\Http;
 use Laminas\I18n\Translator\TranslatorAwareInterface;
 use Laminas\I18n\Translator\TranslatorInterface as Translator;
 use Laminas\Router\Exception;
-use Laminas\Stdlib\RequestInterface as Request;
+use Laminas\Stdlib\RequestInterface;
 
 /**
  * Translator aware tree route stack.
@@ -42,7 +42,7 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
      * @inheritDoc
      * @param int|null $pathOffset
      */
-    public function match(Request $request, $pathOffset = null, array $options = [])
+    public function match(RequestInterface $request, $pathOffset = null, array $options = [])
     {
         if ($this->hasTranslator() && $this->isTranslatorEnabled() && ! isset($options['translator'])) {
             $options['translator'] = $this->getTranslator();

--- a/src/Http/TreeRouteStack.php
+++ b/src/Http/TreeRouteStack.php
@@ -10,7 +10,7 @@ use Laminas\Router\RouteInvokableFactory;
 use Laminas\Router\SimpleRouteStack;
 use Laminas\ServiceManager\Config;
 use Laminas\Stdlib\ArrayUtils;
-use Laminas\Stdlib\RequestInterface as Request;
+use Laminas\Stdlib\RequestInterface;
 use Laminas\Uri\Http as HttpUri;
 use Traversable;
 
@@ -279,7 +279,7 @@ class TreeRouteStack extends SimpleRouteStack
      * @inheritDoc
      * @param int|null $pathOffset
      */
-    public function match(Request $request, $pathOffset = null, array $options = [])
+    public function match(RequestInterface $request, $pathOffset = null, array $options = [])
     {
         if (! method_exists($request, 'getUri')) {
             return null;

--- a/src/Http/TreeRouteStack.php
+++ b/src/Http/TreeRouteStack.php
@@ -12,6 +12,7 @@ use Laminas\ServiceManager\Config;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface;
 use Laminas\Uri\Http as HttpUri;
+use Override;
 use Traversable;
 
 use function array_merge;
@@ -67,6 +68,7 @@ class TreeRouteStack extends SimpleRouteStack
      * @inheritDoc
      * @throws Exception\InvalidArgumentException
      */
+    #[Override]
     public static function factory($options = [])
     {
         if ($options instanceof Traversable) {
@@ -92,6 +94,7 @@ class TreeRouteStack extends SimpleRouteStack
     /**
      * @inheritDoc
      */
+    #[Override]
     protected function init()
     {
         /** @var ArrayObject<string, TRoute> $this->prototypes */
@@ -150,6 +153,7 @@ class TreeRouteStack extends SimpleRouteStack
     /**
      * @inheritDoc
      */
+    #[Override]
     public function addRoute($name, $route, $priority = null)
     {
         if (! $route instanceof HttpRouteInterface) {
@@ -167,6 +171,7 @@ class TreeRouteStack extends SimpleRouteStack
      * @throws Exception\InvalidArgumentException When chain routes are not an array nor traversable.
      * @throws Exception\RuntimeException         When a generated routes does not implement the HTTP route interface.
      */
+    #[Override]
     protected function routeFromArray($specs)
     {
         if (is_string($specs)) {
@@ -279,6 +284,7 @@ class TreeRouteStack extends SimpleRouteStack
      * @inheritDoc
      * @param int|null $pathOffset
      */
+    #[Override]
     public function match(RequestInterface $request, $pathOffset = null, array $options = [])
     {
         if (! method_exists($request, 'getUri')) {
@@ -331,6 +337,7 @@ class TreeRouteStack extends SimpleRouteStack
      * @throws Exception\InvalidArgumentException
      * @throws Exception\RuntimeException
      */
+    #[Override]
     public function assemble(array $params = [], array $options = [])
     {
         if (! isset($options['name'])) {

--- a/src/Http/Wildcard.php
+++ b/src/Http/Wildcard.php
@@ -7,7 +7,7 @@ namespace Laminas\Router\Http;
 use Laminas\Router\Exception;
 use Laminas\Router\RouteInterface;
 use Laminas\Stdlib\ArrayUtils;
-use Laminas\Stdlib\RequestInterface as Request;
+use Laminas\Stdlib\RequestInterface;
 use Traversable;
 
 use function array_merge;
@@ -111,7 +111,7 @@ class Wildcard implements HttpRouteInterface
      * @param  integer|null $pathOffset
      * @return RouteMatch|null
      */
-    public function match(Request $request, $pathOffset = null)
+    public function match(RequestInterface $request, $pathOffset = null)
     {
         if (! method_exists($request, 'getUri')) {
             return null;

--- a/src/Module.php
+++ b/src/Module.php
@@ -6,6 +6,8 @@ namespace Laminas\Router;
 
 /**
  * Register with a laminas-mvc application.
+ *
+ * @final
  */
 class Module
 {

--- a/src/PriorityList.php
+++ b/src/PriorityList.php
@@ -7,9 +7,12 @@ namespace Laminas\Router;
 use Laminas\Stdlib\PriorityList as StdlibPriorityList;
 
 /**
+ * @internal
+ *
  * @template TKey of string
  * @template TValue of RouteInterface
  * @template-extends StdlibPriorityList<TKey, TValue>
+ * @final
  */
 class PriorityList extends StdlibPriorityList
 {

--- a/src/RouteInterface.php
+++ b/src/RouteInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Router;
 
-use Laminas\Stdlib\RequestInterface as Request;
+use Laminas\Stdlib\RequestInterface;
 
 /**
  * RouteInterface interface.
@@ -31,7 +31,7 @@ interface RouteInterface
      *
      * @return RouteMatch|null
      */
-    public function match(Request $request);
+    public function match(RequestInterface $request);
 
     /**
      * Assemble the route.

--- a/src/RouteInvokableFactory.php
+++ b/src/RouteInvokableFactory.php
@@ -19,6 +19,8 @@ use function sprintf;
  *
  * Can be mapped directly to specific route plugin names, or used as an
  * abstract factory to map FQCN services to invokables.
+ *
+ * @internal
  */
 class RouteInvokableFactory implements
     AbstractFactoryInterface,

--- a/src/RoutePluginManager.php
+++ b/src/RoutePluginManager.php
@@ -29,6 +29,7 @@ use function sprintf;
  * @template InstanceType of RouteInterface
  * @extends AbstractPluginManager<InstanceType>
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
+ * @final
  */
 class RoutePluginManager extends AbstractPluginManager
 {

--- a/src/RoutePluginManagerFactory.php
+++ b/src/RoutePluginManagerFactory.php
@@ -8,6 +8,11 @@ use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Psr\Container\ContainerInterface;
 
+/**
+ * @internal
+ *
+ * @final
+ */
 class RoutePluginManagerFactory implements FactoryInterface
 {
     /**

--- a/src/RouterConfigTrait.php
+++ b/src/RouterConfigTrait.php
@@ -10,6 +10,8 @@ use function class_exists;
 use function sprintf;
 
 /**
+ * @internal
+ *
  * @final
  */
 trait RouterConfigTrait

--- a/src/RouterConfigTrait.php
+++ b/src/RouterConfigTrait.php
@@ -9,6 +9,9 @@ use Psr\Container\ContainerInterface;
 use function class_exists;
 use function sprintf;
 
+/**
+ * @final
+ */
 trait RouterConfigTrait
 {
     /**

--- a/src/RouterFactory.php
+++ b/src/RouterFactory.php
@@ -6,6 +6,7 @@ namespace Laminas\Router;
 
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use Override;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -24,6 +25,7 @@ class RouterFactory implements FactoryInterface
      * @param  null|array $options
      * @return RouteStackInterface
      */
+    #[Override]
     public function __invoke(ContainerInterface $container, $name, ?array $options = null)
     {
         return $container->get('HttpRouter');

--- a/src/RouterFactory.php
+++ b/src/RouterFactory.php
@@ -8,6 +8,11 @@ use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Psr\Container\ContainerInterface;
 
+/**
+ * @internal
+ *
+ * @final
+ */
 class RouterFactory implements FactoryInterface
 {
     /**

--- a/src/SimpleRouteStack.php
+++ b/src/SimpleRouteStack.php
@@ -6,7 +6,7 @@ namespace Laminas\Router;
 
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Stdlib\ArrayUtils;
-use Laminas\Stdlib\RequestInterface as Request;
+use Laminas\Stdlib\RequestInterface;
 use Traversable;
 
 use function array_merge;
@@ -255,7 +255,7 @@ class SimpleRouteStack implements RouteStackInterface
     /**
      * @inheritDoc
      */
-    public function match(Request $request)
+    public function match(RequestInterface $request)
     {
         foreach ($this->routes as $name => $route) {
             if (($match = $route->match($request)) instanceof RouteMatch) {

--- a/src/SimpleRouteStack.php
+++ b/src/SimpleRouteStack.php
@@ -7,6 +7,7 @@ namespace Laminas\Router;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\RequestInterface;
+use Override;
 use Traversable;
 
 use function array_merge;
@@ -59,6 +60,7 @@ class SimpleRouteStack implements RouteStackInterface
      * @inheritDoc
      * @throws Exception\InvalidArgumentException
      */
+    #[Override]
     public static function factory($options = [])
     {
         if ($options instanceof Traversable) {
@@ -118,6 +120,7 @@ class SimpleRouteStack implements RouteStackInterface
     }
 
     /** @inheritDoc */
+    #[Override]
     public function addRoutes($routes)
     {
         if (! is_array($routes) && ! $routes instanceof Traversable) {
@@ -132,6 +135,7 @@ class SimpleRouteStack implements RouteStackInterface
     }
 
     /** @inheritDoc */
+    #[Override]
     public function addRoute($name, $route, $priority = null)
     {
         if (! $route instanceof RouteInterface) {
@@ -148,6 +152,7 @@ class SimpleRouteStack implements RouteStackInterface
     }
 
     /** @inheritDoc */
+    #[Override]
     public function removeRoute($name)
     {
         $this->routes->remove($name);
@@ -155,6 +160,7 @@ class SimpleRouteStack implements RouteStackInterface
     }
 
     /** @inheritDoc */
+    #[Override]
     public function setRoutes($routes)
     {
         $this->routes->clear();
@@ -255,6 +261,7 @@ class SimpleRouteStack implements RouteStackInterface
     /**
      * @inheritDoc
      */
+    #[Override]
     public function match(RequestInterface $request)
     {
         foreach ($this->routes as $name => $route) {
@@ -279,6 +286,7 @@ class SimpleRouteStack implements RouteStackInterface
      * @throws Exception\InvalidArgumentException
      * @throws Exception\RuntimeException
      */
+    #[Override]
     public function assemble(array $params = [], array $options = [])
     {
         if (! isset($options['name'])) {

--- a/test/TestAsset/Router.php
+++ b/test/TestAsset/Router.php
@@ -7,7 +7,7 @@ namespace LaminasTest\Router\TestAsset;
 
 use Laminas\Router\RouteInterface;
 use Laminas\Router\RouteStackInterface;
-use Laminas\Stdlib\RequestInterface as Request;
+use Laminas\Stdlib\RequestInterface;
 
 /**
  * @template TRoute of RouteInterface
@@ -26,7 +26,7 @@ final class Router implements RouteStackInterface
     /**
      * @inheritDoc
      */
-    public function match(Request $request)
+    public function match(RequestInterface $request)
     {
         return null;
     }


### PR DESCRIPTION
- Remove not needed class alias
- Add soft `@final` and `@internal`
- Add #[Override] attribute to applicable methods