### PR TITLE
PSR-7 support and stricter route typing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
         "laminas/laminas-servicemanager": "^4.5.0",
         "laminas/laminas-stdlib": "^3.21.0",
-        "laminas/laminas-translator": "^1.3",
+        "laminas/laminas-translator": "^1.3 || ^2.0",
         "psr/container": "^1.1.2 || ^2.0.2",
         "psr/http-message": "^1.1 || ^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -33,16 +33,16 @@
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
         "laminas/laminas-servicemanager": "^4.5.0",
         "laminas/laminas-stdlib": "^3.21.0",
-        "laminas/laminas-uri": "^2.14",
+        "laminas/laminas-translator": "^1.3",
         "psr/container": "^1.1.2 || ^2.0.2",
-        "laminas/laminas-translator": "^1.3"
+        "psr/http-message": "^1.1 || ^2.0"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~3.1.0",
-        "laminas/laminas-http": "^2.23",
+        "laminas/laminas-diactoros": "^3.8",
         "phpunit/phpunit": "^11.5.55",
-        "psalm/plugin-phpunit": "^0.19.5",
-        "vimeo/psalm": "^6.15.1"
+        "psalm/plugin-phpunit": "^0.19.7",
+        "vimeo/psalm": "^6.16.1"
     },
     "suggest": {
         "laminas/laminas-i18n": "^2.15.0 if defining translatable HTTP path segments"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e1dbea51e758b4f0186dbfaff18326ac",
+    "content-hash": "4e9e9fbf953a67af1f719bb815b1b21a",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -201,16 +201,16 @@
         },
         {
             "name": "laminas/laminas-translator",
-            "version": "1.3.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-translator.git",
-                "reference": "1d6bf7d857c3fc310a30f5ea028731b9bf8be9db"
+                "reference": "0169180f44f3d3273bd9a7b00e23ad6b0b870f17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-translator/zipball/1d6bf7d857c3fc310a30f5ea028731b9bf8be9db",
-                "reference": "1d6bf7d857c3fc310a30f5ea028731b9bf8be9db",
+                "url": "https://api.github.com/repos/laminas/laminas-translator/zipball/0169180f44f3d3273bd9a7b00e23ad6b0b870f17",
+                "reference": "0169180f44f3d3273bd9a7b00e23ad6b0b870f17",
                 "shasum": ""
             },
             "require": {
@@ -218,8 +218,8 @@
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~3.1.0",
-                "phpunit/phpunit": "^11.5.46",
-                "vimeo/psalm": "^6.14.3"
+                "phpunit/phpunit": "^11.5.55",
+                "vimeo/psalm": "^6.16.1"
             },
             "type": "library",
             "autoload": {
@@ -251,7 +251,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2025-12-30T14:26:45+00:00"
+            "time": "2026-06-02T11:36:39+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -421,16 +421,16 @@
     "packages-dev": [
         {
             "name": "amphp/amp",
-            "version": "v3.1.1",
+            "version": "v3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/amp.git",
-                "reference": "fa0ab33a6f47a82929c38d03ca47ebb71086a93f"
+                "reference": "2f3ebed5a4f663968a0590dbb7654a8b32cb63cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/amp/zipball/fa0ab33a6f47a82929c38d03ca47ebb71086a93f",
-                "reference": "fa0ab33a6f47a82929c38d03ca47ebb71086a93f",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/2f3ebed5a4f663968a0590dbb7654a8b32cb63cb",
+                "reference": "2f3ebed5a4f663968a0590dbb7654a8b32cb63cb",
                 "shasum": ""
             },
             "require": {
@@ -440,7 +440,7 @@
             "require-dev": {
                 "amphp/php-cs-fixer-config": "^2",
                 "phpunit/phpunit": "^9",
-                "psalm/phar": "5.23.1"
+                "psalm/phar": "6.16.1"
             },
             "type": "library",
             "autoload": {
@@ -490,7 +490,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/amp/issues",
-                "source": "https://github.com/amphp/amp/tree/v3.1.1"
+                "source": "https://github.com/amphp/amp/tree/v3.1.2"
             },
             "funding": [
                 {
@@ -498,7 +498,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-27T21:42:00+00:00"
+            "time": "2026-06-21T13:59:44+00:00"
         },
         {
             "name": "amphp/byte-stream",
@@ -944,16 +944,16 @@
         },
         {
             "name": "amphp/process",
-            "version": "v2.0.3",
+            "version": "v2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/process.git",
-                "reference": "52e08c09dec7511d5fbc1fb00d3e4e79fc77d58d"
+                "reference": "583959df17d00304ad7b0b32285373f985935643"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/process/zipball/52e08c09dec7511d5fbc1fb00d3e4e79fc77d58d",
-                "reference": "52e08c09dec7511d5fbc1fb00d3e4e79fc77d58d",
+                "url": "https://api.github.com/repos/amphp/process/zipball/583959df17d00304ad7b0b32285373f985935643",
+                "reference": "583959df17d00304ad7b0b32285373f985935643",
                 "shasum": ""
             },
             "require": {
@@ -967,7 +967,7 @@
                 "amphp/php-cs-fixer-config": "^2",
                 "amphp/phpunit-util": "^3",
                 "phpunit/phpunit": "^9",
-                "psalm/phar": "^5.4"
+                "psalm/phar": "6.16.1"
             },
             "type": "library",
             "autoload": {
@@ -1000,7 +1000,7 @@
             "homepage": "https://amphp.org/process",
             "support": {
                 "issues": "https://github.com/amphp/process/issues",
-                "source": "https://github.com/amphp/process/tree/v2.0.3"
+                "source": "https://github.com/amphp/process/tree/v2.1.0"
             },
             "funding": [
                 {
@@ -1008,7 +1008,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-04-19T03:13:44+00:00"
+            "time": "2026-05-31T15:11:55+00:00"
         },
         {
             "name": "amphp/serialization",
@@ -1238,28 +1238,29 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.3.2",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/d5a341b3fb61f3001970940afb1d332968a183ed",
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0"
             },
             "conflict": {
-                "phpstan/phpstan": "<1.11.10"
+                "phpstan/phpstan": "<2.2.2"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.12 || ^2",
-                "phpstan/phpstan-strict-rules": "^1 || ^2",
-                "phpunit/phpunit": "^8 || ^9"
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^9"
             },
             "type": "library",
             "extra": {
@@ -1297,7 +1298,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.3.2"
+                "source": "https://github.com/composer/pcre/tree/3.4.0"
             },
             "funding": [
                 {
@@ -1307,13 +1308,9 @@
                 {
                     "url": "https://github.com/composer",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-11-12T16:29:46+00:00"
+            "time": "2026-06-07T11:47:49+00:00"
         },
         {
             "name": "composer/semver",
@@ -4629,16 +4626,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.11",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "ed0107e43ab452aa77ae99e005b95e56b556e075"
+                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/ed0107e43ab452aa77ae99e005b95e56b556e075",
-                "reference": "ed0107e43ab452aa77ae99e005b95e56b556e075",
+                "url": "https://api.github.com/repos/symfony/console/zipball/85095d2573eaefaf35e40b9513a9bf09f72cd217",
+                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217",
                 "shasum": ""
             },
             "require": {
@@ -4703,7 +4700,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.11"
+                "source": "https://github.com/symfony/console/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -4723,7 +4720,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-13T12:04:42+00:00"
+            "time": "2026-05-24T08:56:14+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -4951,16 +4948,16 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e"
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/4864388bfbd3001ce88e234fab652acd91fdc57e",
-                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e9247d281d694a5120554d9afaf54e070e88a603",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603",
                 "shasum": ""
             },
             "require": {
@@ -5009,7 +5006,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -5029,20 +5026,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-26T13:13:48+00:00"
+            "time": "2026-05-26T05:58:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.37.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
                 "shasum": ""
             },
             "require": {
@@ -5094,7 +5091,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -5114,20 +5111,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-25T13:48:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.37.0",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -5179,7 +5176,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -5199,20 +5196,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T17:25:58+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
-                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06"
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/88486db2c389b290bf87ff1de7ebc1e13e42bb06",
-                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
                 "shasum": ""
             },
             "require": {
@@ -5259,7 +5256,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -5279,7 +5276,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T18:47:49+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -5370,16 +5367,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.4.11",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "965f7306a43383d02c6aca1e3f3bd2f0ea5dee15"
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/965f7306a43383d02c6aca1e3f3bd2f0ea5dee15",
-                "reference": "965f7306a43383d02c6aca1e3f3bd2f0ea5dee15",
+                "url": "https://api.github.com/repos/symfony/string/zipball/961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
                 "shasum": ""
             },
             "require": {
@@ -5437,7 +5434,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.4.11"
+                "source": "https://github.com/symfony/string/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -5457,7 +5454,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-13T12:04:42+00:00"
+            "time": "2026-05-23T15:23:29+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -5684,16 +5681,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "2.3.0",
+            "version": "2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "eb0d790f735ba6cff25c683a85a1da0eadeff9e4"
+                "reference": "2ccb7c2e821038c03a3e6e1700c570c158c55f70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/eb0d790f735ba6cff25c683a85a1da0eadeff9e4",
-                "reference": "eb0d790f735ba6cff25c683a85a1da0eadeff9e4",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/2ccb7c2e821038c03a3e6e1700c570c158c55f70",
+                "reference": "2ccb7c2e821038c03a3e6e1700c570c158c55f70",
                 "shasum": ""
             },
             "require": {
@@ -5709,7 +5706,11 @@
             },
             "type": "library",
             "extra": {
+                "psalm": {
+                    "pluginClass": "Webmozart\\Assert\\PsalmPlugin"
+                },
                 "branch-alias": {
+                    "dev-master": "2.0-dev",
                     "dev-feature/2-0": "2.0-dev"
                 }
             },
@@ -5740,9 +5741,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/2.3.0"
+                "source": "https://github.com/webmozarts/assert/tree/2.4.1"
             },
-            "time": "2026-04-11T10:33:05+00:00"
+            "time": "2026-06-15T15:31:57+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "07660a96172039b289b106caed436c30",
+    "content-hash": "e1dbea51e758b4f0186dbfaff18326ac",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -56,78 +56,17 @@
             "time": "2025-02-20T17:42:39+00:00"
         },
         {
-            "name": "laminas/laminas-escaper",
-            "version": "2.18.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-escaper.git",
-                "reference": "06f211dfffff18d91844c1f55250d5d13c007e18"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/06f211dfffff18d91844c1f55250d5d13c007e18",
-                "reference": "06f211dfffff18d91844c1f55250d5d13c007e18",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "ext-mbstring": "*",
-                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
-            },
-            "conflict": {
-                "zendframework/zend-escaper": "*"
-            },
-            "require-dev": {
-                "infection/infection": "^0.31.0",
-                "laminas/laminas-coding-standard": "~3.1.0",
-                "phpunit/phpunit": "^11.5.42",
-                "psalm/plugin-phpunit": "^0.19.5",
-                "vimeo/psalm": "^6.13.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Escaper\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Securely and safely escape HTML, HTML attributes, JavaScript, CSS, and URLs",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "escaper",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-escaper/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-escaper/issues",
-                "rss": "https://github.com/laminas/laminas-escaper/releases.atom",
-                "source": "https://github.com/laminas/laminas-escaper"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2025-10-14T18:31:13+00:00"
-        },
-        {
             "name": "laminas/laminas-servicemanager",
-            "version": "4.5.0",
+            "version": "4.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "a6996829c8ce55025cca1b57b1e8a8b165e3926c"
+                "reference": "11192d588876ad04ba2988984c77b4ecb5c771c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/a6996829c8ce55025cca1b57b1e8a8b165e3926c",
-                "reference": "a6996829c8ce55025cca1b57b1e8a8b165e3926c",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/11192d588876ad04ba2988984c77b4ecb5c771c2",
+                "reference": "11192d588876ad04ba2988984c77b4ecb5c771c2",
                 "shasum": ""
             },
             "require": {
@@ -191,7 +130,7 @@
                 "chat": "https://laminas.dev/chat",
                 "forum": "https://discourse.laminas.dev",
                 "issues": "https://github.com/laminas/laminas-servicemanager/issues",
-                "source": "https://github.com/laminas/laminas-servicemanager/tree/4.5.0"
+                "source": "https://github.com/laminas/laminas-servicemanager/tree/4.5.1"
             },
             "funding": [
                 {
@@ -199,7 +138,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2025-10-14T09:41:04+00:00"
+            "time": "2026-05-12T09:53:32+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
@@ -315,141 +254,6 @@
             "time": "2025-12-30T14:26:45+00:00"
         },
         {
-            "name": "laminas/laminas-uri",
-            "version": "2.14.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-uri.git",
-                "reference": "e804288f4540988903dc0ede386ce5eec87198df"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-uri/zipball/e804288f4540988903dc0ede386ce5eec87198df",
-                "reference": "e804288f4540988903dc0ede386ce5eec87198df",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-escaper": "^2.9",
-                "laminas/laminas-validator": "^2.39 || ^3.0",
-                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
-            },
-            "conflict": {
-                "zendframework/zend-uri": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~2.4.0",
-                "phpunit/phpunit": "^11.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Uri\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "A component that aids in manipulating and validating » Uniform Resource Identifiers (URIs)",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "laminas",
-                "uri"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-uri/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-uri/issues",
-                "rss": "https://github.com/laminas/laminas-uri/releases.atom",
-                "source": "https://github.com/laminas/laminas-uri"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2025-12-05T10:02:11+00:00"
-        },
-        {
-            "name": "laminas/laminas-validator",
-            "version": "3.15.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "9e4ce57074ae4b9b6c03610fd30560c4aefa1a9c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/9e4ce57074ae4b9b6c03610fd30560c4aefa1a9c",
-                "reference": "9e4ce57074ae4b9b6c03610fd30560c4aefa1a9c",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "ext-fileinfo": "*",
-                "ext-filter": "*",
-                "ext-intl": "*",
-                "laminas/laminas-servicemanager": "^4.1.0",
-                "laminas/laminas-stdlib": "^3.19",
-                "laminas/laminas-translator": "^1.0",
-                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
-                "psr/container": "^1.1 || ^2.0",
-                "psr/http-client": "^1.0.3",
-                "psr/http-factory": "^1.1.0",
-                "psr/http-message": "^1.0.1 || ^2.0.0"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "^3.1.0",
-                "laminas/laminas-diactoros": "^3.8.0",
-                "phpunit/phpunit": "^10.5.60",
-                "psalm/plugin-phpunit": "^0.19.5",
-                "vimeo/psalm": "^6.14.2"
-            },
-            "suggest": {
-                "laminas/laminas-i18n": "Laminas\\I18n component to allow translation of validation error messages",
-                "laminas/laminas-i18n-resources": "Translations of validator messages"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "component": "Laminas\\Validator",
-                    "config-provider": "Laminas\\Validator\\ConfigProvider"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Validator\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Validation classes for a wide range of domains, and the ability to chain validators to create complex validation criteria",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "laminas",
-                "validator"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-validator/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-validator/issues",
-                "rss": "https://github.com/laminas/laminas-validator/releases.atom",
-                "source": "https://github.com/laminas/laminas-validator"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2026-02-16T08:59:56+00:00"
-        },
-        {
             "name": "nikic/php-parser",
             "version": "v5.7.0",
             "source": {
@@ -559,113 +363,6 @@
                 "source": "https://github.com/php-fig/container/tree/2.0.2"
             },
             "time": "2021-11-05T16:47:00+00:00"
-        },
-        {
-            "name": "psr/http-client",
-            "version": "1.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-client.git",
-                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
-                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0 || ^8.0",
-                "psr/http-message": "^1.0 || ^2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Client\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for HTTP clients",
-            "homepage": "https://github.com/php-fig/http-client",
-            "keywords": [
-                "http",
-                "http-client",
-                "psr",
-                "psr-18"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/http-client"
-            },
-            "time": "2023-09-23T14:17:50+00:00"
-        },
-        {
-            "name": "psr/http-factory",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-factory.git",
-                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
-                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1",
-                "psr/http-message": "^1.0 || ^2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
-            "keywords": [
-                "factory",
-                "http",
-                "message",
-                "psr",
-                "psr-17",
-                "psr-7",
-                "request",
-                "response"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/http-factory"
-            },
-            "time": "2024-04-15T12:06:14+00:00"
         },
         {
             "name": "psr/http-message",
@@ -1034,16 +731,16 @@
         },
         {
             "name": "amphp/parallel",
-            "version": "v2.3.3",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/parallel.git",
-                "reference": "296b521137a54d3a02425b464e5aee4c93db2c60"
+                "reference": "37f5b2754fadc229c00f9416bd68fb8d04529a81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/parallel/zipball/296b521137a54d3a02425b464e5aee4c93db2c60",
-                "reference": "296b521137a54d3a02425b464e5aee4c93db2c60",
+                "url": "https://api.github.com/repos/amphp/parallel/zipball/37f5b2754fadc229c00f9416bd68fb8d04529a81",
+                "reference": "37f5b2754fadc229c00f9416bd68fb8d04529a81",
                 "shasum": ""
             },
             "require": {
@@ -1063,7 +760,7 @@
                 "amphp/php-cs-fixer-config": "^2",
                 "amphp/phpunit-util": "^3",
                 "phpunit/phpunit": "^9",
-                "psalm/phar": "^5.18"
+                "psalm/phar": "6.16.1"
             },
             "type": "library",
             "autoload": {
@@ -1106,7 +803,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/parallel/issues",
-                "source": "https://github.com/amphp/parallel/tree/v2.3.3"
+                "source": "https://github.com/amphp/parallel/tree/v2.4.0"
             },
             "funding": [
                 {
@@ -1114,7 +811,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-15T06:23:42+00:00"
+            "time": "2026-05-16T16:54:01+00:00"
         },
         {
             "name": "amphp/parser",
@@ -1180,16 +877,16 @@
         },
         {
             "name": "amphp/pipeline",
-            "version": "v1.2.3",
+            "version": "v1.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/pipeline.git",
-                "reference": "7b52598c2e9105ebcddf247fc523161581930367"
+                "reference": "a044733e080940d1483f56caff0c412ad6982776"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/pipeline/zipball/7b52598c2e9105ebcddf247fc523161581930367",
-                "reference": "7b52598c2e9105ebcddf247fc523161581930367",
+                "url": "https://api.github.com/repos/amphp/pipeline/zipball/a044733e080940d1483f56caff0c412ad6982776",
+                "reference": "a044733e080940d1483f56caff0c412ad6982776",
                 "shasum": ""
             },
             "require": {
@@ -1201,7 +898,7 @@
                 "amphp/php-cs-fixer-config": "^2",
                 "amphp/phpunit-util": "^3",
                 "phpunit/phpunit": "^9",
-                "psalm/phar": "^5.18"
+                "psalm/phar": "6.16.1"
             },
             "type": "library",
             "autoload": {
@@ -1235,7 +932,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/pipeline/issues",
-                "source": "https://github.com/amphp/pipeline/tree/v1.2.3"
+                "source": "https://github.com/amphp/pipeline/tree/v1.2.4"
             },
             "funding": [
                 {
@@ -1243,7 +940,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-16T16:33:53+00:00"
+            "time": "2026-05-06T05:37:57+00:00"
         },
         {
             "name": "amphp/process",
@@ -1315,24 +1012,27 @@
         },
         {
             "name": "amphp/serialization",
-            "version": "v1.0.0",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/serialization.git",
-                "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1"
+                "reference": "fdf2834d78cebb0205fb2672676c1b1eb84371f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/serialization/zipball/693e77b2fb0b266c3c7d622317f881de44ae94a1",
-                "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1",
+                "url": "https://api.github.com/repos/amphp/serialization/zipball/fdf2834d78cebb0205fb2672676c1b1eb84371f0",
+                "reference": "fdf2834d78cebb0205fb2672676c1b1eb84371f0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.4"
             },
             "require-dev": {
-                "amphp/php-cs-fixer-config": "dev-master",
-                "phpunit/phpunit": "^9 || ^8 || ^7"
+                "amphp/php-cs-fixer-config": "^2",
+                "ext-json": "*",
+                "ext-zlib": "*",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.1"
             },
             "type": "library",
             "autoload": {
@@ -1367,22 +1067,28 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/serialization/issues",
-                "source": "https://github.com/amphp/serialization/tree/master"
+                "source": "https://github.com/amphp/serialization/tree/v1.1.0"
             },
-            "time": "2020-03-25T21:39:07+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-05T15:59:53+00:00"
         },
         {
             "name": "amphp/socket",
-            "version": "v2.3.1",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/socket.git",
-                "reference": "58e0422221825b79681b72c50c47a930be7bf1e1"
+                "reference": "dadb63c5d3179fd83803e29dfeac27350e619314"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/socket/zipball/58e0422221825b79681b72c50c47a930be7bf1e1",
-                "reference": "58e0422221825b79681b72c50c47a930be7bf1e1",
+                "url": "https://api.github.com/repos/amphp/socket/zipball/dadb63c5d3179fd83803e29dfeac27350e619314",
+                "reference": "dadb63c5d3179fd83803e29dfeac27350e619314",
                 "shasum": ""
             },
             "require": {
@@ -1391,17 +1097,17 @@
                 "amphp/dns": "^2",
                 "ext-openssl": "*",
                 "kelunik/certificate": "^1.1",
-                "league/uri": "^6.5 | ^7",
-                "league/uri-interfaces": "^2.3 | ^7",
+                "league/uri": "^7",
+                "league/uri-interfaces": "^7",
                 "php": ">=8.1",
-                "revolt/event-loop": "^1 || ^0.2"
+                "revolt/event-loop": "^1"
             },
             "require-dev": {
                 "amphp/php-cs-fixer-config": "^2",
                 "amphp/phpunit-util": "^3",
                 "amphp/process": "^2",
                 "phpunit/phpunit": "^9",
-                "psalm/phar": "5.20"
+                "psalm/phar": "6.16.1"
             },
             "type": "library",
             "autoload": {
@@ -1445,7 +1151,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/socket/issues",
-                "source": "https://github.com/amphp/socket/tree/v2.3.1"
+                "source": "https://github.com/amphp/socket/tree/v2.4.0"
             },
             "funding": [
                 {
@@ -1453,7 +1159,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-04-21T14:33:03+00:00"
+            "time": "2026-04-19T15:09:56+00:00"
         },
         {
             "name": "amphp/sync",
@@ -1850,16 +1556,16 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.2.0",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1"
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/845eb62303d2ca9b289ef216356568ccc075ffd1",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
                 "shasum": ""
             },
             "require": {
@@ -1942,7 +1648,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-11T04:32:07+00:00"
+            "time": "2026-05-06T08:26:05+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -2258,117 +1964,84 @@
             "time": "2025-05-13T08:37:04+00:00"
         },
         {
-            "name": "laminas/laminas-http",
-            "version": "2.23.0",
+            "name": "laminas/laminas-diactoros",
+            "version": "3.8.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/laminas/laminas-http.git",
-                "reference": "9462fc84330d25b23383823831380abb33907fdd"
+                "url": "https://github.com/laminas/laminas-diactoros.git",
+                "reference": "60c182916b2749480895601649563970f3f12ec4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-http/zipball/9462fc84330d25b23383823831380abb33907fdd",
-                "reference": "9462fc84330d25b23383823831380abb33907fdd",
+                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/60c182916b2749480895601649563970f3f12ec4",
+                "reference": "60c182916b2749480895601649563970f3f12ec4",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-loader": "^2.10",
-                "laminas/laminas-stdlib": "^3.6",
-                "laminas/laminas-uri": "^2.14",
-                "laminas/laminas-validator": "^2.15 || ^3.0",
-                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/http-factory": "^1.1",
+                "psr/http-message": "^1.1 || ^2.0"
             },
             "conflict": {
-                "zendframework/zend-http": "*"
+                "amphp/amp": "<2.6.4"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "^1.0",
+                "psr/http-message-implementation": "^1.1 || ^2.0"
             },
             "require-dev": {
                 "ext-curl": "*",
-                "laminas/laminas-coding-standard": "^3.0.1",
-                "phpunit/phpunit": "^10.5.38"
-            },
-            "suggest": {
-                "paragonie/certainty": "For automated management of cacert.pem"
+                "ext-dom": "*",
+                "ext-gd": "*",
+                "ext-libxml": "*",
+                "http-interop/http-factory-tests": "^2.2.0",
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "php-http/psr7-integration-tests": "^1.4.0",
+                "phpunit/phpunit": "^10.5.36",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.13"
             },
             "type": "library",
+            "extra": {
+                "laminas": {
+                    "module": "Laminas\\Diactoros",
+                    "config-provider": "Laminas\\Diactoros\\ConfigProvider"
+                }
+            },
             "autoload": {
+                "files": [
+                    "src/functions/create_uploaded_file.php",
+                    "src/functions/marshal_headers_from_sapi.php",
+                    "src/functions/marshal_method_from_sapi.php",
+                    "src/functions/marshal_protocol_version_from_sapi.php",
+                    "src/functions/normalize_server.php",
+                    "src/functions/normalize_uploaded_files.php",
+                    "src/functions/parse_cookie_header.php"
+                ],
                 "psr-4": {
-                    "Laminas\\Http\\": "src/"
+                    "Laminas\\Diactoros\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
-            "description": "Provides an easy interface for performing Hyper-Text Transfer Protocol (HTTP) requests",
+            "description": "PSR HTTP Message implementations",
             "homepage": "https://laminas.dev",
             "keywords": [
                 "http",
-                "http client",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-http/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-http/issues",
-                "rss": "https://github.com/laminas/laminas-http/releases.atom",
-                "source": "https://github.com/laminas/laminas-http"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2025-12-05T11:02:08+00:00"
-        },
-        {
-            "name": "laminas/laminas-loader",
-            "version": "2.12.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-loader.git",
-                "reference": "ec8cee33fb254ee4d9c8e8908c870e5c797e1272"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-loader/zipball/ec8cee33fb254ee4d9c8e8908c870e5c797e1272",
-                "reference": "ec8cee33fb254ee4d9c8e8908c870e5c797e1272",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.0.0"
-            },
-            "conflict": {
-                "zendframework/zend-loader": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~2.4.0",
-                "phpunit/phpunit": "~9.5.25"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Loader\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Autoloading and plugin loading strategies",
-            "homepage": "https://laminas.dev",
-            "keywords": [
                 "laminas",
-                "loader"
+                "psr",
+                "psr-17",
+                "psr-7"
             ],
             "support": {
                 "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-loader/",
+                "docs": "https://docs.laminas.dev/laminas-diactoros/",
                 "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-loader/issues",
-                "rss": "https://github.com/laminas/laminas-loader/releases.atom",
-                "source": "https://github.com/laminas/laminas-loader"
+                "issues": "https://github.com/laminas/laminas-diactoros/issues",
+                "rss": "https://github.com/laminas/laminas-diactoros/releases.atom",
+                "source": "https://github.com/laminas/laminas-diactoros"
             },
             "funding": [
                 {
@@ -2376,25 +2049,24 @@
                     "type": "community_bridge"
                 }
             ],
-            "abandoned": true,
-            "time": "2025-12-30T11:30:39+00:00"
+            "time": "2025-10-12T15:31:36+00:00"
         },
         {
             "name": "league/uri",
-            "version": "7.8.0",
+            "version": "7.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri.git",
-                "reference": "4436c6ec8d458e4244448b069cc572d088230b76"
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri/zipball/4436c6ec8d458e4244448b069cc572d088230b76",
-                "reference": "4436c6ec8d458e4244448b069cc572d088230b76",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/08cf38e3924d4f56238125547b5720496fac8fd4",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4",
                 "shasum": ""
             },
             "require": {
-                "league/uri-interfaces": "^7.8",
+                "league/uri-interfaces": "^7.8.1",
                 "php": "^8.1",
                 "psr/http-factory": "^1"
             },
@@ -2467,7 +2139,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri/tree/7.8.0"
+                "source": "https://github.com/thephpleague/uri/tree/7.8.1"
             },
             "funding": [
                 {
@@ -2475,20 +2147,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-14T17:24:56+00:00"
+            "time": "2026-03-15T20:22:25+00:00"
         },
         {
             "name": "league/uri-interfaces",
-            "version": "7.8.0",
+            "version": "7.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri-interfaces.git",
-                "reference": "c5c5cd056110fc8afaba29fa6b72a43ced42acd4"
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/c5c5cd056110fc8afaba29fa6b72a43ced42acd4",
-                "reference": "c5c5cd056110fc8afaba29fa6b72a43ced42acd4",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928",
                 "shasum": ""
             },
             "require": {
@@ -2551,7 +2223,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.0"
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.1"
             },
             "funding": [
                 {
@@ -2559,7 +2231,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-15T06:54:53+00:00"
+            "time": "2026-03-08T20:05:35+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2845,16 +2517,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "6.0.2",
+            "version": "6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "897b5986ece6b4f9d8413fea345c7d49c757d6bf"
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/897b5986ece6b4f9d8413fea345c7d49c757d6bf",
-                "reference": "897b5986ece6b4f9d8413fea345c7d49c757d6bf",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/7bae67520aa9f5ecc506d646810bd40d9da54582",
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582",
                 "shasum": ""
             },
             "require": {
@@ -2904,9 +2576,9 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.2"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.3"
             },
-            "time": "2026-03-01T18:43:49+00:00"
+            "time": "2026-03-18T20:49:53+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -3472,7 +3144,7 @@
         },
         {
             "name": "psalm/plugin-phpunit",
-            "version": "0.19.5",
+            "version": "0.19.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/psalm/psalm-plugin-phpunit.git",
@@ -3524,9 +3196,64 @@
             "description": "Psalm plugin for PHPUnit",
             "support": {
                 "issues": "https://github.com/psalm/psalm-plugin-phpunit/issues",
-                "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.19.5"
+                "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.19.7"
             },
             "time": "2025-03-31T18:49:55+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
         },
         {
             "name": "psr/log",
@@ -3580,16 +3307,16 @@
         },
         {
             "name": "revolt/event-loop",
-            "version": "v1.0.8",
+            "version": "v1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/revoltphp/event-loop.git",
-                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c"
+                "reference": "44061cf513e53c6200372fc935ac42271566295d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/b6fc06dce8e9b523c9946138fa5e62181934f91c",
-                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c",
+                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/44061cf513e53c6200372fc935ac42271566295d",
+                "reference": "44061cf513e53c6200372fc935ac42271566295d",
                 "shasum": ""
             },
             "require": {
@@ -3599,7 +3326,7 @@
                 "ext-json": "*",
                 "jetbrains/phpstorm-stubs": "^2019.3",
                 "phpunit/phpunit": "^9",
-                "psalm/phar": "^5.15"
+                "psalm/phar": "6.16.*"
             },
             "type": "library",
             "extra": {
@@ -3646,9 +3373,9 @@
             ],
             "support": {
                 "issues": "https://github.com/revoltphp/event-loop/issues",
-                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.8"
+                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.9"
             },
-            "time": "2025-08-27T21:33:23+00:00"
+            "time": "2026-05-16T17:55:38+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -4902,16 +4629,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.7",
+            "version": "v7.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "e1e6770440fb9c9b0cf725f81d1361ad1835329d"
+                "reference": "ed0107e43ab452aa77ae99e005b95e56b556e075"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/e1e6770440fb9c9b0cf725f81d1361ad1835329d",
-                "reference": "e1e6770440fb9c9b0cf725f81d1361ad1835329d",
+                "url": "https://api.github.com/repos/symfony/console/zipball/ed0107e43ab452aa77ae99e005b95e56b556e075",
+                "reference": "ed0107e43ab452aa77ae99e005b95e56b556e075",
                 "shasum": ""
             },
             "require": {
@@ -4976,7 +4703,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.7"
+                "source": "https://github.com/symfony/console/tree/v7.4.11"
             },
             "funding": [
                 {
@@ -4996,20 +4723,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-06T14:06:20+00:00"
+            "time": "2026-05-13T12:04:42+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
                 "shasum": ""
             },
             "require": {
@@ -5022,7 +4749,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -5047,7 +4774,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -5059,24 +4786,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-04-13T15:52:40+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.4.6",
+            "version": "v7.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "3ebc794fa5315e59fd122561623c2e2e4280538e"
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/3ebc794fa5315e59fd122561623c2e2e4280538e",
-                "reference": "3ebc794fa5315e59fd122561623c2e2e4280538e",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
                 "shasum": ""
             },
             "require": {
@@ -5113,7 +4844,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.4.6"
+                "source": "https://github.com/symfony/filesystem/tree/v7.4.11"
             },
             "funding": [
                 {
@@ -5133,20 +4864,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-25T16:50:00+00:00"
+            "time": "2026-05-11T16:38:44+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
@@ -5196,7 +4927,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -5216,20 +4947,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70"
+                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/380872130d3a5dd3ace2f4010d95125fde5d5c70",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/4864388bfbd3001ce88e234fab652acd91fdc57e",
+                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e",
                 "shasum": ""
             },
             "require": {
@@ -5278,7 +5009,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -5298,11 +5029,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T09:58:17+00:00"
+            "time": "2026-04-26T13:13:48+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -5363,7 +5094,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -5387,16 +5118,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
                 "shasum": ""
             },
             "require": {
@@ -5448,7 +5179,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -5468,20 +5199,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2026-04-10T17:25:58+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
-                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191"
+                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/d8ced4d875142b6a7426000426b8abc631d6b191",
-                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/88486db2c389b290bf87ff1de7ebc1e13e42bb06",
+                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06",
                 "shasum": ""
             },
             "require": {
@@ -5528,7 +5259,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -5548,20 +5279,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-24T13:30:11+00:00"
+            "time": "2026-04-10T18:47:49+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
                 "shasum": ""
             },
             "require": {
@@ -5579,7 +5310,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -5615,7 +5346,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -5635,20 +5366,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T11:30:57+00:00"
+            "time": "2026-03-28T09:44:51+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v7.4.6",
+            "version": "v7.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "9f209231affa85aa930a5e46e6eb03381424b30b"
+                "reference": "965f7306a43383d02c6aca1e3f3bd2f0ea5dee15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/9f209231affa85aa930a5e46e6eb03381424b30b",
-                "reference": "9f209231affa85aa930a5e46e6eb03381424b30b",
+                "url": "https://api.github.com/repos/symfony/string/zipball/965f7306a43383d02c6aca1e3f3bd2f0ea5dee15",
+                "reference": "965f7306a43383d02c6aca1e3f3bd2f0ea5dee15",
                 "shasum": ""
             },
             "require": {
@@ -5706,7 +5437,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.4.6"
+                "source": "https://github.com/symfony/string/tree/v7.4.11"
             },
             "funding": [
                 {
@@ -5726,7 +5457,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-09T09:33:46+00:00"
+            "time": "2026-05-13T12:04:42+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -5780,16 +5511,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "6.15.1",
+            "version": "6.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "28dc127af1b5aecd52314f6f645bafc10d0e11f9"
+                "reference": "f1f5de594dc76faf8784e02d3dc4716c91c6f6ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/28dc127af1b5aecd52314f6f645bafc10d0e11f9",
-                "reference": "28dc127af1b5aecd52314f6f645bafc10d0e11f9",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/f1f5de594dc76faf8784e02d3dc4716c91c6f6ac",
+                "reference": "f1f5de594dc76faf8784e02d3dc4716c91c6f6ac",
                 "shasum": ""
             },
             "require": {
@@ -5894,7 +5625,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2026-02-07T19:27:16+00:00"
+            "time": "2026-03-19T10:56:09+00:00"
         },
         {
             "name": "webimpress/coding-standard",
@@ -5953,16 +5684,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "2.1.6",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "ff31ad6efc62e66e518fbab1cde3453d389bcdc8"
+                "reference": "eb0d790f735ba6cff25c683a85a1da0eadeff9e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/ff31ad6efc62e66e518fbab1cde3453d389bcdc8",
-                "reference": "ff31ad6efc62e66e518fbab1cde3453d389bcdc8",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/eb0d790f735ba6cff25c683a85a1da0eadeff9e4",
+                "reference": "eb0d790f735ba6cff25c683a85a1da0eadeff9e4",
                 "shasum": ""
             },
             "require": {
@@ -6009,9 +5740,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/2.1.6"
+                "source": "https://github.com/webmozarts/assert/tree/2.3.0"
             },
-            "time": "2026-02-27T10:28:38+00:00"
+            "time": "2026-04-11T10:33:05+00:00"
         }
     ],
     "aliases": [],
@@ -6026,5 +5757,5 @@
     "platform-overrides": {
         "php": "8.2.99"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,91 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.15.1@28dc127af1b5aecd52314f6f645bafc10d0e11f9">
-  <file src="src/Http/Hostname.php">
-    <PossiblyUnusedProperty>
-      <code><![CDATA[$priority]]></code>
-    </PossiblyUnusedProperty>
-  </file>
-  <file src="src/Http/Literal.php">
-    <PossiblyUnusedProperty>
-      <code><![CDATA[$priority]]></code>
-    </PossiblyUnusedProperty>
-  </file>
-  <file src="src/Http/Method.php">
-    <PossiblyUnusedProperty>
-      <code><![CDATA[$priority]]></code>
-    </PossiblyUnusedProperty>
-  </file>
-  <file src="src/Http/Part.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA[(string) $name]]></code>
-    </ArgumentTypeCoercion>
-    <InvalidArgument>
-      <code><![CDATA[new self(
-            $routePlugins,
-            $prototypes,
-            $route,
-            [],
-            $mayTerminate,
-            $childRoutes,
-        )]]></code>
-    </InvalidArgument>
-  </file>
-  <file src="src/Http/Placeholder.php">
-    <PossiblyUnusedProperty>
-      <code><![CDATA[$priority]]></code>
-    </PossiblyUnusedProperty>
-  </file>
-  <file src="src/Http/Regex.php">
-    <PossiblyUnusedProperty>
-      <code><![CDATA[$priority]]></code>
-    </PossiblyUnusedProperty>
-  </file>
-  <file src="src/Http/Scheme.php">
-    <MoreSpecificImplementedParamType>
-      <code><![CDATA[$options]]></code>
-    </MoreSpecificImplementedParamType>
-    <PossiblyUnusedProperty>
-      <code><![CDATA[$priority]]></code>
-    </PossiblyUnusedProperty>
-  </file>
-  <file src="src/Http/Segment.php">
-    <PossiblyUnusedProperty>
-      <code><![CDATA[$priority]]></code>
-    </PossiblyUnusedProperty>
-  </file>
+<files psalm-version="6.16.1@f1f5de594dc76faf8784e02d3dc4716c91c6f6ac">
   <file src="src/Http/TreeRouteStack.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA[(string) $name]]></code>
-    </ArgumentTypeCoercion>
-    <DeprecatedProperty>
-      <code><![CDATA[$route->priority]]></code>
-      <code><![CDATA[$route->priority]]></code>
-    </DeprecatedProperty>
-    <InvalidReturnStatement>
-      <code><![CDATA[$route]]></code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code><![CDATA[TRoute]]></code>
-    </InvalidReturnType>
-    <NoInterfaceProperties>
-      <code><![CDATA[$route->priority]]></code>
-    </NoInterfaceProperties>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$route]]></code>
-    </PossiblyInvalidArgument>
     <UnsafeGenericInstantiation>
       <code><![CDATA[new static(
             $routePlugins,
-            $prototypes,
             $routes,
-            $defaultParams
+            $defaultParams,
         )]]></code>
     </UnsafeGenericInstantiation>
-  </file>
-  <file src="src/PriorityList.php">
-    <InvalidTemplateParam>
-      <code><![CDATA[PriorityList]]></code>
-    </InvalidTemplateParam>
   </file>
   <file src="src/RoutePluginManager.php">
     <MethodSignatureMismatch>
@@ -96,48 +18,12 @@
     </MixedArgument>
   </file>
   <file src="src/SimpleRouteStack.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA[(string) $name]]></code>
-    </ArgumentTypeCoercion>
-    <MixedAssignment>
-      <code><![CDATA[$route]]></code>
-    </MixedAssignment>
-    <NoInterfaceProperties>
-      <code><![CDATA[$route->priority]]></code>
-      <code><![CDATA[$route->priority]]></code>
-    </NoInterfaceProperties>
-    <UnsafeInstantiation>
+    <UnsafeGenericInstantiation>
       <code><![CDATA[new static(
             $routePlugins,
             $routes,
             $defaultParams
         )]]></code>
-    </UnsafeInstantiation>
-  </file>
-  <file src="test/Http/TestAsset/DummyRoute.php">
-    <UnsafeInstantiation>
-      <code><![CDATA[new static()]]></code>
-    </UnsafeInstantiation>
-  </file>
-  <file src="test/Http/TreeRouteStackTest.php">
-    <NoInterfaceProperties>
-      <code><![CDATA[$foo->priority]]></code>
-    </NoInterfaceProperties>
-  </file>
-  <file src="test/SimpleRouteStackTest.php">
-    <DeprecatedProperty>
-      <code><![CDATA[$route->priority]]></code>
-    </DeprecatedProperty>
-    <NoInterfaceProperties>
-      <code><![CDATA[$route->priority]]></code>
-    </NoInterfaceProperties>
-  </file>
-  <file src="test/TestAsset/DummyRoute.php">
-    <PossiblyUnusedProperty>
-      <code><![CDATA[$priority]]></code>
-    </PossiblyUnusedProperty>
-    <UnsafeInstantiation>
-      <code><![CDATA[new static()]]></code>
-    </UnsafeInstantiation>
+    </UnsafeGenericInstantiation>
   </file>
 </files>

--- a/src/AssembledUrl.php
+++ b/src/AssembledUrl.php
@@ -4,26 +4,23 @@ declare(strict_types=1);
 
 namespace Laminas\Router;
 
-use Stringable;
-
 use function array_merge;
 use function http_build_query;
 use function sprintf;
 use function str_starts_with;
 use function strtolower;
 
-readonly final class AssembledUrl implements Stringable
+readonly final class AssembledUrl
 {
+    /**
+     * @param array<string, scalar> $query
+     * @param non-empty-string|null $host
+     * @param non-empty-string|null $scheme
+     */
     public function __construct(
         public string $path = '',
         public array $query = [],
-        /**
-         * @var non-empty-string|null
-         */
         public ?string $host = null,
-        /**
-         * @var non-empty-string|null
-         */
         public ?string $scheme = null,
         public ?string $fragment = null,
         public bool $forceCanonical = false,
@@ -44,7 +41,7 @@ readonly final class AssembledUrl implements Stringable
         );
     }
 
-    public function __toString(): string
+    public function toString(): string
     {
         $uri = $this->path;
 

--- a/src/AssembledUrl.php
+++ b/src/AssembledUrl.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Router;
+
+use Stringable;
+
+use function array_merge;
+use function http_build_query;
+use function sprintf;
+use function str_starts_with;
+use function strtolower;
+
+readonly final class AssembledUrl implements Stringable
+{
+    public function __construct(
+        public string $path = '',
+        public array $query = [],
+        /**
+         * @var non-empty-string|null
+         */
+        public ?string $host = null,
+        /**
+         * @var non-empty-string|null
+         */
+        public ?string $scheme = null,
+        public ?string $fragment = null,
+        public bool $forceCanonical = false,
+        public ?int $port = null,
+    ) {
+    }
+
+    public function merge(self $other): self
+    {
+        return new self(
+            path: $this->path . $other->path,
+            query: array_merge($this->query, $other->query),
+            host: $other->host ?? $this->host,
+            scheme: $other->scheme ?? $this->scheme,
+            fragment: $other->fragment ?? $this->fragment,
+            forceCanonical: $this->forceCanonical || $other->forceCanonical,
+            port: $other->port ?? $this->port,
+        );
+    }
+
+    public function __toString(): string
+    {
+        $uri = $this->path;
+
+        if ($this->forceCanonical && $this->host !== null) {
+            $scheme    = $this->scheme ?? 'http';
+            $authority = $this->host;
+            if ($this->port !== null && $this->shouldEmitPort($scheme, $this->port)) {
+                $authority .= ':' . $this->port;
+            }
+
+            $uri = sprintf('%s://%s', $scheme, $authority);
+
+            $pathPart = $this->path;
+            if ($pathPart === '') {
+                $pathPart = '/';
+            } elseif (! str_starts_with($pathPart, '/')) {
+                $pathPart = '/' . $pathPart;
+            }
+
+            $uri .= $pathPart;
+        }
+
+        if (! empty($this->query)) {
+            $uri .= '?' . http_build_query($this->query);
+        }
+
+        if ($this->fragment !== null) {
+            $uri .= '#' . $this->fragment;
+        }
+
+        return $uri;
+    }
+
+    private function shouldEmitPort(string $scheme, ?int $port): bool
+    {
+        if ($port === null) {
+            return false;
+        }
+
+        $scheme = strtolower($scheme);
+
+        return ! (($scheme === 'http' && $port === 80) || ($scheme === 'https' && $port === 443));
+    }
+}

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -26,7 +26,7 @@ use Laminas\ServiceManager\ServiceManager;
  *      }
  *  }
  */
-final class ConfigProvider
+final readonly class ConfigProvider
 {
     /**
      * Provide default configuration.

--- a/src/Http/Chain.php
+++ b/src/Http/Chain.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Laminas\Router\Http;
 
-use ArrayObject;
+use Laminas\Router\AssembledUrl;
 use Laminas\Router\Exception;
 use Laminas\Router\Http\HttpRouteMatch;
 use Laminas\Router\RoutePluginManager;
-use Laminas\Stdlib\RequestInterface;
-use Laminas\Uri\Http;
 use Override;
+use Psr\Http\Message\RequestInterface;
 
 use function array_diff_key;
 use function array_flip;
@@ -19,7 +18,6 @@ use function array_reverse;
 use function assert;
 use function is_array;
 use function is_bool;
-use function method_exists;
 use function strlen;
 
 /**
@@ -46,17 +44,16 @@ final class Chain extends TreeRouteStack implements HttpRouteInterface
      * Create a new part route.
      *
      * @param array<array-key, array|TRoute> $routes
-     * @param ArrayObject<string, TRoute> $prototypes
      * @param array<non-empty-string, non-empty-string> $defaultParams
      */
     public function __construct(
         RoutePluginManager $routePluginManager,
-        ArrayObject $prototypes,
         array $routes = [],
-        array $defaultParams = []
+        array $defaultParams = [],
+        ?int $priority = null,
     ) {
         $this->chainRoutes = array_reverse($routes);
-        parent::__construct($routePluginManager, $prototypes, [], $defaultParams);
+        parent::__construct($routePluginManager, [], $defaultParams, $priority);
     }
 
     /**
@@ -66,12 +63,9 @@ final class Chain extends TreeRouteStack implements HttpRouteInterface
     #[Override]
     public static function factory(array $options = []): static
     {
-        $route = $options['routes'] ?? null;
-        /** @var ArrayObject<string, TRoute> $prototypes */
-        $prototypes   = $options['prototypes'] ?? new ArrayObject();
         $routePlugins = $options['route_plugins'] ?? null;
 
-        if ($route === null) {
+        if (! isset($options['routes']) || ! is_array($options['routes'])) {
             throw new Exception\InvalidArgumentException('Missing "routes" in options array');
         }
 
@@ -79,15 +73,18 @@ final class Chain extends TreeRouteStack implements HttpRouteInterface
             throw new Exception\InvalidArgumentException('Missing "route_plugins" in options array');
         }
 
-        assert(is_array($route));
-
+        /** @psalm-var array<non-empty-string, array|TRoute> $routes */
+        $routes = $options['routes'];
         /** @psalm-var RoutePluginManager $routePlugins */
-        /** @psalm-var array<non-empty-string, TRoute> $route */
+
+        /** @psalm-var int|null $priority */
+        $priority = $options['priority'] ?? null;
 
         return new self(
             $routePlugins,
-            $prototypes,
-            $route,
+            $routes,
+            [],
+            $priority,
         );
     }
 
@@ -95,10 +92,6 @@ final class Chain extends TreeRouteStack implements HttpRouteInterface
     #[Override]
     public function match(RequestInterface $request, int|null $pathOffset = null, array $options = []): ?HttpRouteMatch
     {
-        if (! method_exists($request, 'getUri')) {
-            return null;
-        }
-
         $mustTerminate = $pathOffset === null;
         $pathOffset  ??= 0;
 
@@ -107,10 +100,8 @@ final class Chain extends TreeRouteStack implements HttpRouteInterface
             $this->chainRoutes = null;
         }
 
-        $match = new HttpRouteMatch([]);
-        /** @var Http $uri */
-        $uri        = $request->getUri();
-        $pathLength = strlen((string) $uri->getPath());
+        $match      = new HttpRouteMatch([]);
+        $pathLength = strlen($request->getUri()->getPath());
 
         foreach ($this->routes as $route) {
             assert($route instanceof HttpRouteInterface);
@@ -135,8 +126,10 @@ final class Chain extends TreeRouteStack implements HttpRouteInterface
 
     /** @inheritDoc */
     #[Override]
-    public function assemble(array $params = [], array $options = []): string
+    public function assemble(array $params = [], array $options = []): AssembledUrl
     {
+        $finalResult = new AssembledUrl();
+
         if ($this->chainRoutes !== null) {
             $this->addRoutes($this->chainRoutes);
             $this->chainRoutes = null;
@@ -146,7 +139,6 @@ final class Chain extends TreeRouteStack implements HttpRouteInterface
 
         $routes       = [...$this->routes];
         $lastRouteKey = array_key_last($routes);
-        $path         = '';
 
         foreach ($routes as $key => $route) {
             assert($route instanceof HttpRouteInterface);
@@ -155,7 +147,9 @@ final class Chain extends TreeRouteStack implements HttpRouteInterface
 
             $chainOptions['has_child'] = $hasChild || $key !== $lastRouteKey;
 
-            $path  .= $route->assemble($params, $chainOptions);
+            $assembledUrl = $route->assemble($params, $chainOptions);
+            $finalResult  = $finalResult->merge($assembledUrl);
+
             $params = array_diff_key($params, array_flip($route->getAssembledParams()));
 
             $this->assembledParams = [
@@ -164,7 +158,7 @@ final class Chain extends TreeRouteStack implements HttpRouteInterface
             ];
         }
 
-        return $path;
+        return $finalResult;
     }
 
     /** @inheritDoc */

--- a/src/Http/Hostname.php
+++ b/src/Http/Hostname.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Router\Http;
 
+use Laminas\Router\AssembledUrl;
 use Laminas\Router\Exception;
 use Laminas\Router\Http\HttpRouteMatch;
 use Laminas\Router\Http\RouteDefinition\RouteDefinition;
@@ -11,14 +12,11 @@ use Laminas\Router\Http\RouteDefinition\RouteDefinitionLiteral;
 use Laminas\Router\Http\RouteDefinition\RouteDefinitionOption;
 use Laminas\Router\Http\RouteDefinition\RouteDefinitionParameter;
 use Laminas\Router\Http\RouteDefinition\RouteDefinitionPartInterface;
-use Laminas\Stdlib\RequestInterface;
-use Laminas\Uri\Http;
-use Laminas\Uri\Http as HttpUri;
 use Override;
+use Psr\Http\Message\RequestInterface;
 
 use function array_merge;
 use function is_string;
-use function method_exists;
 use function preg_match;
 use function preg_quote;
 use function sprintf;
@@ -52,11 +50,6 @@ final class Hostname implements HttpRouteInterface
      * @var list<non-empty-string>
      */
     private array $assembledParams = [];
-    /**
-     * @internal
-     * @deprecated Since 3.9.0 This property will be removed or made private in version 4.0
-     */
-    public int|null $priority = null;
 
     /**
      * Create a new hostname route.
@@ -67,7 +60,8 @@ final class Hostname implements HttpRouteInterface
     public function __construct(
         string $route,
         array $constraints = [],
-        private readonly array $defaults = []
+        private readonly array $defaults = [],
+        private readonly int|null $priority = null,
     ) {
         $this->parts = $this->parseRouteDefinition($route);
         $this->regex = $this->buildRegex($this->parts->getParts(), $constraints);
@@ -85,12 +79,14 @@ final class Hostname implements HttpRouteInterface
         $constraints = $options['constraints'] ?? [];
         /** @psalm-var array<string, string> $defaults */
         $defaults = $options['defaults'] ?? [];
+        /** @psalm-var int|null $priority */
+        $priority = $options['priority'] ?? null;
 
         if (! is_string($route)) {
             throw new Exception\InvalidArgumentException('Missing "route" in options array');
         }
 
-        return new self($route, $constraints, $defaults);
+        return new self($route, $constraints, $defaults, $priority);
     }
 
     /**
@@ -192,8 +188,9 @@ final class Hostname implements HttpRouteInterface
      * @param array<string, string|null|int|float> $mergedParams
      * @throws Exception\RuntimeException
      * @throws Exception\InvalidArgumentException
+     * @return non-empty-string|null
      */
-    private function buildHost(array $parts, array $mergedParams, bool $isOptional): string
+    private function buildHost(array $parts, array $mergedParams, bool $isOptional): string|null
     {
         $host      = '';
         $skip      = true;
@@ -213,7 +210,7 @@ final class Hostname implements HttpRouteInterface
                         throw new Exception\InvalidArgumentException(sprintf('Missing parameter "%s"', $part->name));
                     }
 
-                    return '';
+                    return null;
                 } elseif (
                     ! $isOptional
                     || ! isset($this->defaults[$part->name])
@@ -232,7 +229,7 @@ final class Hostname implements HttpRouteInterface
                 $skippable    = true;
                 $optionalPart = $this->buildHost($part->part, $mergedParams, true);
 
-                if ($optionalPart !== '') {
+                if ($optionalPart !== null) {
                     $host .= $optionalPart;
                     $skip  = false;
                 }
@@ -240,24 +237,17 @@ final class Hostname implements HttpRouteInterface
         }
 
         if ($isOptional && $skippable && $skip) {
-            return '';
+            return null;
         }
 
-        return $host;
+        return $host === '' ? null : $host;
     }
 
     /** @inheritDoc */
     #[Override]
     public function match(RequestInterface $request, int|null $pathOffset = null, array $options = []): ?HttpRouteMatch
     {
-        if (! method_exists($request, 'getUri')) {
-            return null;
-        }
-
-        /** @var Http $uri */
-        $uri  = $request->getUri();
-        $host = $uri->getHost() ?? '';
-
+        $host   = $request->getUri()->getHost();
         $result = preg_match('(^' . $this->regex . '$)', $host, $matches);
 
         if (! $result) {
@@ -277,22 +267,19 @@ final class Hostname implements HttpRouteInterface
 
     /** @inheritDoc */
     #[Override]
-    public function assemble(array $params = [], array $options = []): string
+    public function assemble(array $params = [], array $options = []): AssembledUrl
     {
         $this->assembledParams = [];
 
-        if (isset($options['uri']) && $options['uri'] instanceof HttpUri) {
-            $host = $this->buildHost(
-                $this->parts->getParts(),
-                array_merge($this->defaults, $params),
-                false
-            );
+        $host = $this->buildHost(
+            $this->parts->getParts(),
+            array_merge($this->defaults, $params),
+            false
+        );
 
-            $options['uri']->setHost($host);
-        }
-
-        // A hostname does not contribute to the path, thus nothing is returned.
-        return '';
+        return new AssembledUrl(
+            host: $host,
+        );
     }
 
     /** @inheritDoc */
@@ -300,5 +287,11 @@ final class Hostname implements HttpRouteInterface
     public function getAssembledParams(): array
     {
         return $this->assembledParams;
+    }
+
+    #[Override]
+    public function getPriority(): ?int
+    {
+        return $this->priority;
     }
 }

--- a/src/Http/HttpRouteInterface.php
+++ b/src/Http/HttpRouteInterface.php
@@ -6,7 +6,7 @@ namespace Laminas\Router\Http;
 
 use Laminas\Router\RouteInterface;
 use Laminas\Router\RouteMatch;
-use Laminas\Stdlib\RequestInterface;
+use Psr\Http\Message\RequestInterface;
 
 /**
  * Tree specific route interface.

--- a/src/Http/Literal.php
+++ b/src/Http/Literal.php
@@ -4,30 +4,23 @@ declare(strict_types=1);
 
 namespace Laminas\Router\Http;
 
+use Laminas\Router\AssembledUrl;
 use Laminas\Router\Exception;
 use Laminas\Router\Http\HttpRouteMatch;
-use Laminas\Stdlib\RequestInterface;
-use Laminas\Uri\Http;
 use Override;
+use Psr\Http\Message\RequestInterface;
 
 use function assert;
 use function is_array;
 use function is_string;
-use function method_exists;
 use function strlen;
 use function strpos;
 
 /**
  * Literal route.
  */
-final class Literal implements HttpRouteInterface
+final readonly class Literal implements HttpRouteInterface
 {
-    /**
-     * @internal
-     * @deprecated Since 3.9.0 This property will be removed or made private in version 4.0
-     */
-    public int|null $priority = null;
-
     /**
      * Create a new literal route.
      *
@@ -37,11 +30,12 @@ final class Literal implements HttpRouteInterface
         /**
          * RouteInterface to match.
          */
-        private readonly string $route,
+        private string $route,
         /**
          * Default values.
          */
-        private readonly array $defaults = []
+        private array $defaults = [],
+        private int|null $priority = null
     ) {
     }
 
@@ -54,6 +48,8 @@ final class Literal implements HttpRouteInterface
     {
         $route    = $options['route'] ?? null;
         $defaults = $options['defaults'] ?? [];
+        /** @psalm-var int|null $priority */
+        $priority = $options['priority'] ?? null;
 
         if (! is_string($route)) {
             throw new Exception\InvalidArgumentException('Missing "route" in options array');
@@ -63,20 +59,14 @@ final class Literal implements HttpRouteInterface
 
         /** @psalm-var array<string, string> $defaults */
 
-        return new self($route, $defaults);
+        return new self($route, $defaults, $priority);
     }
 
     /** @inheritDoc */
     #[Override]
     public function match(RequestInterface $request, int|null $pathOffset = null, array $options = []): ?HttpRouteMatch
     {
-        if (! method_exists($request, 'getUri')) {
-            return null;
-        }
-
-        /** @var Http $uri */
-        $uri  = $request->getUri();
-        $path = (string) $uri->getPath();
+        $path = $request->getUri()->getPath();
 
         if ($pathOffset !== null) {
             if ($pathOffset >= 0 && strlen($path) >= $pathOffset && ! empty($this->route)) {
@@ -92,14 +82,18 @@ final class Literal implements HttpRouteInterface
             return new HttpRouteMatch($this->defaults, strlen($this->route));
         }
 
+        if ($this->route === '/' && ($path === '' || $path === '/')) {
+            return new HttpRouteMatch($this->defaults, strlen($this->route));
+        }
+
         return null;
     }
 
     /** @inheritDoc */
     #[Override]
-    public function assemble(array $params = [], array $options = []): string
+    public function assemble(array $params = [], array $options = []): AssembledUrl
     {
-        return $this->route;
+        return new AssembledUrl(path:$this->route);
     }
 
     /** @inheritDoc */
@@ -107,5 +101,11 @@ final class Literal implements HttpRouteInterface
     public function getAssembledParams(): array
     {
         return [];
+    }
+
+    #[Override]
+    public function getPriority(): ?int
+    {
+        return $this->priority;
     }
 }

--- a/src/Http/Method.php
+++ b/src/Http/Method.php
@@ -4,30 +4,24 @@ declare(strict_types=1);
 
 namespace Laminas\Router\Http;
 
+use Laminas\Router\AssembledUrl;
 use Laminas\Router\Exception;
 use Laminas\Router\Http\HttpRouteMatch;
-use Laminas\Stdlib\RequestInterface;
 use Override;
+use Psr\Http\Message\RequestInterface;
 
 use function array_map;
 use function explode;
 use function in_array;
 use function is_string;
-use function method_exists;
 use function strtoupper;
 use function trim;
 
 /**
  * Method route.
  */
-final class Method implements HttpRouteInterface
+final readonly class Method implements HttpRouteInterface
 {
-    /**
-     * @internal
-     * @deprecated Since 3.9.0 This property will be removed or made private in version 4.0
-     */
-    public int|null $priority = null;
-
     /**
      * Create a new method route.
      *
@@ -37,11 +31,12 @@ final class Method implements HttpRouteInterface
         /**
          * Verb to match.
          */
-        private readonly string $verb,
+        private string $verb,
         /**
          * Default values.
          */
-        private readonly array $defaults = []
+        private array $defaults = [],
+        private int|null $priority = null
     ) {
     }
 
@@ -56,23 +51,21 @@ final class Method implements HttpRouteInterface
         $verb = $options['verb'] ?? null;
         /** @psalm-var array<string, string> $defaults */
         $defaults = $options['defaults'] ?? [];
+        /** @psalm-var int|null $priority */
+        $priority = $options['priority'] ?? null;
 
         if (! is_string($verb)) {
             throw new Exception\InvalidArgumentException('Missing "verb" in options array');
         }
 
-        return new self($verb, $defaults);
+        return new self($verb, $defaults, $priority);
     }
 
     /** @inheritDoc */
     #[Override]
     public function match(RequestInterface $request, int|null $pathOffset = null, array $options = []): ?HttpRouteMatch
     {
-        if (! method_exists($request, 'getMethod')) {
-            return null;
-        }
-
-        $requestVerb = strtoupper((string) $request->getMethod());
+        $requestVerb = strtoupper($request->getMethod());
         $matchVerbs  = explode(',', strtoupper($this->verb));
         $matchVerbs  = array_map(trim(...), $matchVerbs);
 
@@ -85,10 +78,10 @@ final class Method implements HttpRouteInterface
 
     /** @inheritDoc */
     #[Override]
-    public function assemble(array $params = [], array $options = []): string
+    public function assemble(array $params = [], array $options = []): AssembledUrl
     {
         // The request method does not contribute to the path, thus nothing is returned.
-        return '';
+        return new AssembledUrl();
     }
 
     /** @inheritDoc */
@@ -96,5 +89,11 @@ final class Method implements HttpRouteInterface
     public function getAssembledParams(): array
     {
         return [];
+    }
+
+    #[Override]
+    public function getPriority(): ?int
+    {
+        return $this->priority;
     }
 }

--- a/src/Http/Part.php
+++ b/src/Http/Part.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Laminas\Router\Http;
 
-use ArrayObject;
+use Laminas\Router\AssembledUrl;
 use Laminas\Router\Exception;
 use Laminas\Router\RouteMatch;
 use Laminas\Router\RoutePluginManager;
-use Laminas\Stdlib\RequestInterface;
-use Laminas\Uri\Http;
 use Override;
+use Psr\Http\Message\RequestInterface;
 
 use function array_diff_key;
 use function array_flip;
@@ -18,9 +17,8 @@ use function assert;
 use function count;
 use function is_array;
 use function is_bool;
-use function is_object;
+use function is_int;
 use function is_string;
-use function method_exists;
 use function strlen;
 
 /**
@@ -39,25 +37,24 @@ final class Part extends TreeRouteStack implements HttpRouteInterface
     /**
      * Create a new part route.
      *
-     * @param TRoute|array|string           $routes
-     * @param ArrayObject<string, TRoute> $prototypes
+     * @param TRoute|array           $routes
      * @param array<non-empty-string, array|TRoute> $childRoutes
      * @throws Exception\InvalidArgumentException
      */
     public function __construct(
         RoutePluginManager $routePluginManager,
-        ArrayObject $prototypes,
-        HttpRouteInterface|array|string $routes = [],
+        HttpRouteInterface|array $routes = [],
         array $defaultParams = [],
+        ?int $priority = null,
         /**
          * Whether the route may terminate.
          */
         private readonly bool $mayTerminate = false,
         private array $childRoutes = [],
     ) {
-        parent::__construct($routePluginManager, $prototypes);
+        parent::__construct($routePluginManager, priority: $priority);
 
-        if (! is_object($routes)) {
+        if (is_array($routes)) {
             $routes = $this->routeFromArray($routes);
         }
 
@@ -75,10 +72,8 @@ final class Part extends TreeRouteStack implements HttpRouteInterface
     #[Override]
     public static function factory(array $options = []): static
     {
-        $route        = $options['route'] ?? null;
+        $routes       = $options['route'] ?? null;
         $routePlugins = $options['route_plugins'] ?? null;
-        /** @var ArrayObject<string, TRoute> $prototypes */
-        $prototypes   = $options['prototypes'] ?? new ArrayObject();
         $mayTerminate = $options['may_terminate'] ?? false;
         /** @var array<non-empty-string, TRoute> $childRoutes */
         $childRoutes = $options['child_routes'] ?? [];
@@ -87,18 +82,23 @@ final class Part extends TreeRouteStack implements HttpRouteInterface
             throw new Exception\InvalidArgumentException('Missing "route_plugins" in options array');
         }
 
-        if ($route === null) {
+        if ($routes === null) {
             throw new Exception\InvalidArgumentException('Missing "route" in options array');
         }
 
         assert(is_bool($mayTerminate));
-        assert(is_array($route) || is_string($route) || $route instanceof HttpRouteInterface);
+        assert(is_array($routes) || $routes instanceof HttpRouteInterface);
+
+        /** @psalm-var int|null $priority */
+        $priority = $options['priority'] ?? null;
+
+        /** @psalm-var TRoute|array $routes */
 
         return new self(
             $routePlugins,
-            $prototypes,
-            $route,
+            $routes,
             [],
+            is_int($priority) ? $priority : null,
             $mayTerminate,
             $childRoutes,
         );
@@ -116,7 +116,7 @@ final class Part extends TreeRouteStack implements HttpRouteInterface
 
         assert($match instanceof HttpRouteMatch || $match === null);
 
-        if ($match !== null && method_exists($request, 'getUri')) {
+        if ($match !== null) {
             if (count($this->childRoutes) !== 0) {
                 $this->addRoutes($this->childRoutes);
                 $this->childRoutes = [];
@@ -124,9 +124,7 @@ final class Part extends TreeRouteStack implements HttpRouteInterface
 
             $nextOffset = $pathOffset + $match->getLength();
 
-            /** @var Http $uri */
-            $uri        = $request->getUri();
-            $pathLength = strlen((string) $uri->getPath());
+            $pathLength = strlen($request->getUri()->getPath());
 
             if ($this->mayTerminate && $nextOffset === $pathLength) {
                 return $match;
@@ -141,12 +139,12 @@ final class Part extends TreeRouteStack implements HttpRouteInterface
             }
 
             foreach ($this->routes as $name => $route) {
-                assert($name !== '');
+                assert(is_string($name));
                 assert($route instanceof HttpRouteInterface);
                 $subMatch = $route->match($request, $nextOffset, $options);
                 if ($subMatch instanceof HttpRouteMatch) {
                     if (($match->getLength() + $subMatch->getLength() + $pathOffset) === $pathLength) {
-                        return $match->merge($subMatch)->setMatchedRouteName((string) $name);
+                        return $match->merge($subMatch)->setMatchedRouteName($name);
                     }
                 }
             }
@@ -160,7 +158,7 @@ final class Part extends TreeRouteStack implements HttpRouteInterface
      * @throws Exception\RuntimeException
      */
     #[Override]
-    public function assemble(array $params = [], array $options = []): string
+    public function assemble(array $params = [], array $options = []): AssembledUrl
     {
         if (count($this->childRoutes) !== 0) {
             $this->addRoutes($this->childRoutes);
@@ -173,7 +171,7 @@ final class Part extends TreeRouteStack implements HttpRouteInterface
             $options['locale'] = $params['locale'];
         }
 
-        $path   = $this->route->assemble($params, $options);
+        $uri    = $this->route->assemble($params, $options);
         $params = array_diff_key($params, array_flip($this->route->getAssembledParams()));
 
         if (! isset($options['name'])) {
@@ -181,12 +179,13 @@ final class Part extends TreeRouteStack implements HttpRouteInterface
                 throw new Exception\RuntimeException('Part route may not terminate');
             }
 
-            return $path;
+            return $uri;
         }
 
         unset($options['has_child']);
         $options['only_return_path'] = true;
-        return $path . parent::assemble($params, $options);
+
+        return $uri->merge(parent::assemble($params, $options));
     }
 
     /** @inheritDoc */

--- a/src/Http/Placeholder.php
+++ b/src/Http/Placeholder.php
@@ -4,28 +4,24 @@ declare(strict_types=1);
 
 namespace Laminas\Router\Http;
 
+use Laminas\Router\AssembledUrl;
 use Laminas\Router\Exception;
 use Laminas\Router\Http\HttpRouteMatch;
-use Laminas\Stdlib\RequestInterface;
 use Override;
+use Psr\Http\Message\RequestInterface;
 
 /**
  * Placeholder route.
  */
-final class Placeholder implements HttpRouteInterface
+final readonly class Placeholder implements HttpRouteInterface
 {
-    /**
-     * @internal
-     * @deprecated Since 3.9.0 This property will be removed or made private in version 4.0
-     */
-    public int|null $priority = null;
-
     /**
      * @param array<string, string> $defaults
      */
     public function __construct(
         /** @var array<string, string> */
-        private readonly array $defaults
+        private array $defaults,
+        private int|null $priority = null
     ) {
     }
 
@@ -38,8 +34,10 @@ final class Placeholder implements HttpRouteInterface
     {
         /** @var array<string, string> $defaults */
         $defaults = $options['defaults'] ?? [];
+        /** @psalm-var int|null $priority */
+        $priority = $options['priority'] ?? null;
 
-        return new self($defaults);
+        return new self($defaults, $priority);
     }
 
     /** @inheritDoc */
@@ -54,9 +52,9 @@ final class Placeholder implements HttpRouteInterface
 
     /** @inheritDoc */
     #[Override]
-    public function assemble(array $params = [], array $options = []): string
+    public function assemble(array $params = [], array $options = []): AssembledUrl
     {
-        return '';
+        return new AssembledUrl();
     }
 
     /** @inheritDoc */
@@ -64,5 +62,11 @@ final class Placeholder implements HttpRouteInterface
     public function getAssembledParams(): array
     {
         return [];
+    }
+
+    #[Override]
+    public function getPriority(): ?int
+    {
+        return $this->priority;
     }
 }

--- a/src/Http/Regex.php
+++ b/src/Http/Regex.php
@@ -4,18 +4,17 @@ declare(strict_types=1);
 
 namespace Laminas\Router\Http;
 
+use Laminas\Router\AssembledUrl;
 use Laminas\Router\Exception;
 use Laminas\Router\Exception\InvalidArgumentException;
 use Laminas\Router\Http\HttpRouteMatch;
-use Laminas\Stdlib\RequestInterface;
-use Laminas\Uri\Http;
 use Override;
+use Psr\Http\Message\RequestInterface;
 
 use function array_merge;
 use function assert;
 use function is_array;
 use function is_string;
-use function method_exists;
 use function preg_match;
 use function rawurldecode;
 use function rawurlencode;
@@ -34,12 +33,6 @@ final class Regex implements HttpRouteInterface
      * @var list<non-empty-string>
      */
     private array $assembledParams = [];
-
-    /**
-     * @internal
-     * @deprecated Since 3.9.0 This property will be removed or made private in version 4.0
-     */
-    public int|null $priority = null;
 
     /**
      * Create a new regex route.
@@ -64,7 +57,8 @@ final class Regex implements HttpRouteInterface
          *
          * @var array<non-empty-string, string|int>
          */
-        private readonly array $defaults = []
+        private readonly array $defaults = [],
+        private readonly int|null $priority = null
     ) {
     }
 
@@ -78,6 +72,8 @@ final class Regex implements HttpRouteInterface
         $regex    = $options['regex'] ?? null;
         $spec     = $options['spec'] ?? null;
         $defaults = $options['defaults'] ?? [];
+        /** @psalm-var int|null $priority */
+        $priority = $options['priority'] ?? null;
 
         if (! is_string($regex) || $regex === '') {
             throw new Exception\InvalidArgumentException('Missing "regex" in options array');
@@ -89,25 +85,19 @@ final class Regex implements HttpRouteInterface
 
         /** @psalm-var array<non-empty-string, non-empty-string> $defaults */
 
-        return new self($regex, $spec, $defaults);
+        return new self($regex, $spec, $defaults, $priority);
     }
 
     /** @inheritDoc */
     #[Override]
     public function match(RequestInterface $request, int|null $pathOffset = null, array $options = []): ?HttpRouteMatch
     {
-        if (! method_exists($request, 'getUri')) {
-            return null;
-        }
-
-        /** @var Http $uri */
-        $uri  = $request->getUri();
-        $path = $uri->getPath();
+        $path = $request->getUri()->getPath();
 
         if ($pathOffset !== null) {
-            $result = preg_match('(\G' . $this->regex . ')', (string) $path, $matches, 0, $pathOffset);
+            $result = preg_match('(\G' . $this->regex . ')', $path, $matches, 0, $pathOffset);
         } else {
-            $result = preg_match('(^' . $this->regex . '$)', (string) $path, $matches);
+            $result = preg_match('(^' . $this->regex . '$)', $path, $matches);
         }
 
         if (! $result) {
@@ -129,7 +119,7 @@ final class Regex implements HttpRouteInterface
 
     /** @inheritDoc */
     #[Override]
-    public function assemble(array $params = [], array $options = []): string
+    public function assemble(array $params = [], array $options = []): AssembledUrl
     {
         $url                   = $this->spec;
         $mergedParams          = array_merge($this->defaults, $params);
@@ -145,7 +135,7 @@ final class Regex implements HttpRouteInterface
             }
         }
 
-        return $url;
+        return new AssembledUrl(path:$url);
     }
 
     /** @inheritDoc */
@@ -153,5 +143,11 @@ final class Regex implements HttpRouteInterface
     public function getAssembledParams(): array
     {
         return $this->assembledParams;
+    }
+
+    #[Override]
+    public function getPriority(): ?int
+    {
+        return $this->priority;
     }
 }

--- a/src/Http/Scheme.php
+++ b/src/Http/Scheme.php
@@ -4,26 +4,19 @@ declare(strict_types=1);
 
 namespace Laminas\Router\Http;
 
+use Laminas\Router\AssembledUrl;
 use Laminas\Router\Exception;
 use Laminas\Router\Http\HttpRouteMatch;
-use Laminas\Stdlib\RequestInterface;
-use Laminas\Uri\Http;
 use Override;
+use Psr\Http\Message\RequestInterface;
 
 use function is_string;
-use function method_exists;
 
 /**
  * Scheme route.
  */
-final class Scheme implements HttpRouteInterface
+final readonly class Scheme implements HttpRouteInterface
 {
-    /**
-     * @internal
-     * @deprecated Since 3.9.0 This property will be removed or made private in version 4.0
-     */
-    public int|null $priority = null;
-
     /**
      * Create a new scheme route.
      *
@@ -32,44 +25,40 @@ final class Scheme implements HttpRouteInterface
     public function __construct(
         /**
          * Scheme to match.
+         *
+         * @var non-empty-string
          */
-        private readonly string $scheme,
+        private string $scheme,
         /**
          * Default values.
          */
-        private readonly array $defaults = []
+        private array $defaults = [],
+        private int|null $priority = null
     ) {
     }
 
-    /**
-     * @param array{'scheme'?:string, 'defaults'?: array<string, string>} $options
-     */
     #[Override]
     public static function factory(array $options = []): static
     {
-        $scheme   = $options['scheme'] ?? null;
+        /** @psalm-var string|null $scheme */
+        $scheme = $options['scheme'] ?? null;
+        /** @psalm-var array<string, string> $defaults */
         $defaults = $options['defaults'] ?? [];
+        /** @psalm-var int|null $priority */
+        $priority = $options['priority'] ?? null;
 
         if (! is_string($scheme) || $scheme === '') {
             throw new Exception\InvalidArgumentException('Missing "scheme" in options array');
         }
 
-        return new self($scheme, $defaults);
+        return new self($scheme, $defaults, $priority);
     }
 
     /** @inheritDoc */
     #[Override]
     public function match(RequestInterface $request, int|null $pathOffset = null, array $options = []): ?HttpRouteMatch
     {
-        if (! method_exists($request, 'getUri')) {
-            return null;
-        }
-
-        /** @var Http $uri */
-        $uri    = $request->getUri();
-        $scheme = $uri->getScheme();
-
-        if ($scheme !== $this->scheme) {
+        if ($request->getUri()->getScheme() !== $this->scheme) {
             return null;
         }
 
@@ -78,14 +67,9 @@ final class Scheme implements HttpRouteInterface
 
     /** @inheritDoc */
     #[Override]
-    public function assemble(array $params = [], array $options = []): string
+    public function assemble(array $params = [], array $options = []): AssembledUrl
     {
-        if (isset($options['uri']) && $options['uri'] instanceof Http) {
-            $options['uri']->setScheme($this->scheme);
-        }
-
-        // A scheme does not contribute to the path, thus nothing is returned.
-        return '';
+        return new AssembledUrl(scheme:$this->scheme);
     }
 
     /** @inheritDoc */
@@ -93,5 +77,11 @@ final class Scheme implements HttpRouteInterface
     public function getAssembledParams(): array
     {
         return [];
+    }
+
+    #[Override]
+    public function getPriority(): ?int
+    {
+        return $this->priority;
     }
 }

--- a/src/Http/Segment.php
+++ b/src/Http/Segment.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Router\Http;
 
+use Laminas\Router\AssembledUrl;
 use Laminas\Router\Exception;
 use Laminas\Router\Http\RouteDefinition\RouteDefinition;
 use Laminas\Router\Http\RouteDefinition\RouteDefinitionLiteral;
@@ -11,15 +12,13 @@ use Laminas\Router\Http\RouteDefinition\RouteDefinitionOption;
 use Laminas\Router\Http\RouteDefinition\RouteDefinitionParameter;
 use Laminas\Router\Http\RouteDefinition\RouteDefinitionPartInterface;
 use Laminas\Router\Http\RouteDefinition\RouteDefinitionTranslatedLiteral;
-use Laminas\Stdlib\RequestInterface;
 use Laminas\Translator\TranslatorInterface as Translator;
-use Laminas\Uri\Http;
 use Override;
+use Psr\Http\Message\RequestInterface;
 
 use function array_key_exists;
 use function array_merge;
 use function is_string;
-use function method_exists;
 use function preg_match;
 use function preg_quote;
 use function rawurldecode;
@@ -105,12 +104,6 @@ final class Segment implements HttpRouteInterface
     private array $translationKeys = [];
 
     /**
-     * @internal
-     * @deprecated Since 3.9.0 This property will be removed or made private in version 4.0
-     */
-    public int|null $priority = null;
-
-    /**
      * Create a new regex route.
      *
      * @param array<string, string> $constraints
@@ -119,7 +112,8 @@ final class Segment implements HttpRouteInterface
     public function __construct(
         string $route,
         array $constraints = [],
-        private array $defaults = []
+        private array $defaults = [],
+        private readonly int|null $priority = null,
     ) {
         $this->parts = $this->parseRouteDefinition($route);
         $this->regex = $this->buildRegex($this->parts->getParts(), $constraints);
@@ -137,12 +131,14 @@ final class Segment implements HttpRouteInterface
         $constraints = $options['constraints'] ?? [];
         /** @psalm-var array<non-empty-string, string> $defaults */
         $defaults = $options['defaults'] ?? [];
+        /** @psalm-var int|null $priority */
+        $priority = $options['priority'] ?? null;
 
         if (! is_string($route)) {
             throw new Exception\InvalidArgumentException('Missing "route" in options array');
         }
 
-        return new self($route, $constraints, $defaults);
+        return new self($route, $constraints, $defaults, $priority);
     }
 
     /**
@@ -343,13 +339,7 @@ final class Segment implements HttpRouteInterface
     #[Override]
     public function match(RequestInterface $request, int|null $pathOffset = null, array $options = []): ?HttpRouteMatch
     {
-        if (! method_exists($request, 'getUri')) {
-            return null;
-        }
-
-        /** @var Http $uri */
-        $uri   = $request->getUri();
-        $path  = $uri->getPath();
+        $path  = $request->getUri()->getPath();
         $regex = $this->regex;
 
         if ($this->translationKeys) {
@@ -369,9 +359,9 @@ final class Segment implements HttpRouteInterface
         }
 
         if ($pathOffset !== null) {
-            $result = preg_match('(\G' . $regex . ')', (string) $path, $matches, 0, $pathOffset);
+            $result = preg_match('(\G' . $regex . ')', $path, $matches, 0, $pathOffset);
         } else {
-            $result = preg_match('(^' . $regex . '$)', (string) $path, $matches);
+            $result = preg_match('(^' . $regex . '$)', $path, $matches);
         }
 
         if (! $result) {
@@ -392,17 +382,17 @@ final class Segment implements HttpRouteInterface
 
     /** @inheritDoc */
     #[Override]
-    public function assemble(array $params = [], array $options = []): string
+    public function assemble(array $params = [], array $options = []): AssembledUrl
     {
         $this->assembledParams = [];
 
-        return $this->buildPath(
+        return new AssembledUrl(path :$this->buildPath(
             $this->parts->getParts(),
             array_merge($this->defaults, $params),
             false,
             array_key_exists('has_child', $options) && $options['has_child'] === true,
             $options
-        );
+        ));
     }
 
     /** @inheritDoc */
@@ -410,6 +400,12 @@ final class Segment implements HttpRouteInterface
     public function getAssembledParams(): array
     {
         return $this->assembledParams;
+    }
+
+    #[Override]
+    public function getPriority(): ?int
+    {
+        return $this->priority;
     }
 
     /**

--- a/src/Http/TranslatorAwareTreeRouteStack.php
+++ b/src/Http/TranslatorAwareTreeRouteStack.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Laminas\Router\Http;
 
+use Laminas\Router\AssembledUrl;
 use Laminas\Router\Exception;
 use Laminas\Router\RouteMatch;
-use Laminas\Stdlib\RequestInterface;
 use Laminas\Translator\TranslatorInterface;
 use Override;
+use Psr\Http\Message\RequestInterface;
 
 /**
  * Translator aware tree route stack.
@@ -57,7 +58,7 @@ final class TranslatorAwareTreeRouteStack extends TreeRouteStack
      * @throws Exception\RuntimeException
      */
     #[Override]
-    public function assemble(array $params = [], array $options = []): string
+    public function assemble(array $params = [], array $options = []): AssembledUrl
     {
         if ($this->hasTranslator() && $this->isTranslatorEnabled() && ! isset($options['translator'])) {
             $options['translator'] = $this->getTranslator();

--- a/src/Http/TreeRouteStack.php
+++ b/src/Http/TreeRouteStack.php
@@ -4,25 +4,23 @@ declare(strict_types=1);
 
 namespace Laminas\Router\Http;
 
-use ArrayObject;
+use Laminas\Router\AssembledUrl;
 use Laminas\Router\Exception;
 use Laminas\Router\Exception\RuntimeException;
 use Laminas\Router\RouteInterface;
 use Laminas\Router\RouteMatch;
 use Laminas\Router\RoutePluginManager;
 use Laminas\Router\SimpleRouteStack;
-use Laminas\Stdlib\RequestInterface;
-use Laminas\Uri\Http as HttpUri;
 use Override;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\UriInterface;
 
+use function array_key_exists;
 use function array_merge;
 use function assert;
 use function explode;
 use function is_array;
 use function is_string;
-use function method_exists;
-use function property_exists;
-use function rtrim;
 use function sprintf;
 use function strlen;
 
@@ -36,37 +34,19 @@ use function strlen;
 class TreeRouteStack extends SimpleRouteStack
 {
     /**
-     * Base URL.
-     */
-    private string|null $baseUrl = null;
-
-    /**
      * Request URI.
      */
-    private HttpUri|null $requestUri = null;
+    private UriInterface|null $requestUri = null;
 
     /**
-     * @internal
-     * @deprecated Since 3.9.0 This property will be removed or made private in version 4.0
-     */
-    public int|null $priority = null;
-
-    /**
-     * @param ArrayObject<string, TRoute> $prototypes
      * @param array<non-empty-string, array|TRoute> $routes
      * @param array<non-empty-string, non-empty-string> $defaultParams
      */
     public function __construct(
         private readonly RoutePluginManager $routePluginManager,
-        /**
-         * Prototype routes.
-         *
-         * We use an ArrayObject in this case so we can easily pass it down the tree
-         * by reference.
-         */
-        private readonly ArrayObject $prototypes,
         array $routes = [],
-        array $defaultParams = []
+        array $defaultParams = [],
+        protected readonly int|null $priority = null,
     ) {
         parent::__construct($this->routePluginManager, $routes, $defaultParams);
     }
@@ -79,9 +59,7 @@ class TreeRouteStack extends SimpleRouteStack
     public static function factory(array $options = []): static
     {
         /** @psalm-var array<non-empty-string, array|TRoute>  $routes */
-        $routes = $options['routes'] ?? [];
-        /** @var ArrayObject<string, TRoute> $prototypes */
-        $prototypes   = $options['prototypes'] ?? new ArrayObject();
+        $routes       = $options['routes'] ?? [];
         $routePlugins = $options['route_plugins'] ?? null;
         /** @psalm-var array<non-empty-string, non-empty-string> $defaultParams */
         $defaultParams = $options['default_params'] ?? [];
@@ -92,43 +70,42 @@ class TreeRouteStack extends SimpleRouteStack
 
         return new static(
             $routePlugins,
-            $prototypes,
             $routes,
-            $defaultParams
+            $defaultParams,
         );
     }
 
-    /** @inheritDoc */
+    /**
+     * @inheritDoc
+     */
     #[Override]
-    public function addRoute(string|int $name, int|string|array|RouteInterface $route, ?int $priority = null): void
+    public function addRoute(string $name, array|RouteInterface $route, ?int $priority = null): void
     {
-        if (! $route instanceof HttpRouteInterface && $route instanceof RouteInterface) {
+        if ($route instanceof RouteInterface && ! $route instanceof HttpRouteInterface) {
             throw new Exception\InvalidArgumentException(
                 'Only HttpRouteInterface instances or array/string specifications are allowed.'
             );
         }
-        if (! $route instanceof HttpRouteInterface) {
+        if (is_array($route)) {
             $route = $this->routeFromArray($route);
         }
+
+        assert($route instanceof HttpRouteInterface);
 
         parent::addRoute($name, $route, $priority);
     }
 
     /**
      * @inheritDoc
-     * @param  string|array $specs
+     * @param  array $specs
      * @return TRoute
      * @throws Exception\InvalidArgumentException When route definition is not an array nor traversable.
      * @throws Exception\InvalidArgumentException When chain routes are not an array nor traversable.
      * @throws Exception\RuntimeException         When a generated routes does not implement the HTTP route interface.
      */
     #[Override]
-    final protected function routeFromArray(string|array $specs): RouteInterface
+    final protected function routeFromArray(array $specs): RouteInterface
     {
-        if (is_string($specs)) {
-            return $this->getPrototype($specs);
-        }
-
         if (isset($specs['chain_routes'])) {
             if (! is_array($specs['chain_routes'])) {
                 throw new Exception\InvalidArgumentException('Chain routes must be an array');
@@ -146,7 +123,6 @@ class TreeRouteStack extends SimpleRouteStack
             $options = [
                 'routes'        => $chainRoutes,
                 'route_plugins' => $this->routePluginManager,
-                'prototypes'    => $this->prototypes,
             ];
 
             $route = $this->routePluginManager->build(Chain::class, $options);
@@ -164,29 +140,18 @@ class TreeRouteStack extends SimpleRouteStack
                 'may_terminate' => isset($specs['may_terminate']) && $specs['may_terminate'] === true,
                 'child_routes'  => $specs['child_routes'],
                 'route_plugins' => $this->routePluginManager,
-                'prototypes'    => $this->prototypes,
             ];
 
-            $priority = $route->priority ?? null;
-
-            $route           = $this->routePluginManager->build(Part::class, $options);
-            $route->priority = $priority;
+            $route = $this->routePluginManager->build(Part::class, [
+                ...$options,
+                'priority' => $route->getPriority(),
+            ]);
         }
 
+        assert($route instanceof HttpRouteInterface);
+
+        /** @psalm-var TRoute $route */
         return $route;
-    }
-
-    /**
-     * Get a prototype.
-     *
-     * @return TRoute
-     */
-    private function getPrototype(string $name): RouteInterface
-    {
-        if (! property_exists($this->prototypes, $name)) {
-            throw new Exception\RuntimeException(sprintf('Could not find prototype with name %s', $name));
-        }
-        return $this->prototypes[$name];
     }
 
     /**
@@ -199,36 +164,23 @@ class TreeRouteStack extends SimpleRouteStack
         int|null $pathOffset = null,
         array $options = []
     ): ?RouteMatch {
-        if (! method_exists($request, 'getUri')) {
-            return null;
-        }
-
-        if ($this->baseUrl === null && method_exists($request, 'getBaseUrl')) {
-            $this->setBaseUrl((string) $request->getBaseUrl());
-        }
-
-        /** @var HttpUri $uri */
-        $uri           = $request->getUri();
-        $baseUrlLength = strlen((string) $this->baseUrl) ?: null;
-
-        if ($pathOffset !== null) {
-            $baseUrlLength = $baseUrlLength !== null ? $baseUrlLength + $pathOffset : $pathOffset;
-        }
+        $baseUrlLength = $pathOffset;
 
         if ($this->requestUri === null) {
-            $this->setRequestUri($uri);
+            $this->setRequestUri($request->getUri());
         }
 
         $pathLength = null;
         if ($baseUrlLength !== null) {
-            $pathLength = strlen((string) $uri->getPath()) - $baseUrlLength;
+            $pathLength = strlen($request->getUri()->getPath()) - $baseUrlLength;
         }
 
         foreach ($this->routes as $name => $route) {
+            assert(is_string($name));
             assert($route instanceof HttpRouteInterface);
             $match = $route->match($request, $baseUrlLength, $options);
             if ($match instanceof HttpRouteMatch && ($pathLength === null || $match->getLength() === $pathLength)) {
-                $match->setMatchedRouteName((string) $name);
+                $match->setMatchedRouteName($name);
 
                 foreach ($this->defaultParams as $paramName => $value) {
                     if ($match->getParam($paramName) === null) {
@@ -244,12 +196,9 @@ class TreeRouteStack extends SimpleRouteStack
     }
 
     /**
-     * @inheritDoc
-     * @throws Exception\InvalidArgumentException
-     * @throws Exception\RuntimeException
+     * @return array{name : non-empty-string, child : string|null}
      */
-    #[Override]
-    public function assemble(array $params = [], array $options = []): string
+    private function getRouteName(array $options): array
     {
         $name = $options['name'] ?? '';
         if (! is_string($name) || $name === '') {
@@ -262,114 +211,94 @@ class TreeRouteStack extends SimpleRouteStack
             throw new Exception\RuntimeException('Invalid route name');
         }
 
-        $route = $this->routes->get($names[0]);
+        return [
+            'name'  => $names[0],
+            'child' => $names[1] ?? null,
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     * @throws Exception\InvalidArgumentException
+     * @throws Exception\RuntimeException
+     */
+    #[Override]
+    public function assemble(array $params = [], array $options = []): AssembledUrl
+    {
+        $names = $this->getRouteName($options);
+        $route = $this->routes->get($names['name']);
 
         if (! $route) {
-            throw new Exception\RuntimeException(sprintf('Route with name "%s" not found', $names[0]));
+            throw new Exception\RuntimeException(sprintf('Route with name "%s" not found', $names['name']));
         }
 
-        if (isset($names[1])) {
+        if ($names['child'] !== null) {
             if (! $route instanceof TreeRouteStack) {
                 throw new Exception\RuntimeException(sprintf(
                     'Route with name "%s" does not have child routes',
-                    $names[0]
+                    $names['name']
                 ));
             }
-            $options['name'] = $names[1];
+            $options['name'] = $names['child'];
         } else {
             unset($options['name']);
         }
 
+        $assembledUrl = $route->assemble(array_merge($this->defaultParams, $params), $options);
+
         if (isset($options['only_return_path']) && $options['only_return_path'] === true) {
-            return ($this->baseUrl ?? '') . $route->assemble(array_merge($this->defaultParams, $params), $options);
+            return $assembledUrl;
         }
 
-        if (! isset($options['uri']) || ! $options['uri'] instanceof HttpUri) {
-            $uri = new HttpUri();
+        $forceCanonical = isset($options['force_canonical']) && $options['force_canonical'] === true;
+        $contextUri     = isset($options['uri']) && $options['uri'] instanceof UriInterface ? $options['uri'] : null;
+        $fallbackUri    = $contextUri ?? $this->requestUri;
 
-            if (isset($options['force_canonical']) && $options['force_canonical'] === true) {
-                if ($this->requestUri === null) {
-                    throw new Exception\RuntimeException('Request URI has not been set');
-                }
-
-                $uri->setScheme($this->requestUri->getScheme())
-                    ->setHost($this->requestUri->getHost())
-                    ->setPort($this->requestUri->getPort());
-            }
-
-            $options['uri'] = $uri;
-        } else {
-            $uri = $options['uri'];
+        if ($forceCanonical && $fallbackUri === null) {
+            throw new RuntimeException('Request URI has not been set');
         }
 
-        $path = ($this->baseUrl ?? '') . $route->assemble(array_merge($this->defaultParams, $params), $options);
+        $normalizeNonEmpty = static fn(?string $value): ?string => $value === '' ? null : $value;
+        $resolvedPort      = $assembledUrl->port ?? $fallbackUri?->getPort();
+        $resolvedScheme    = $assembledUrl->scheme ?? $normalizeNonEmpty($fallbackUri?->getScheme());
+        $resolvedHost      = $assembledUrl->host ?? $normalizeNonEmpty($fallbackUri?->getHost());
 
-        if (isset($options['query']) && (is_string($options['query']) || is_array($options['query']))) {
-            $uri->setQuery($options['query']);
+        if ($resolvedHost !== null && $resolvedScheme === null) {
+            throw new RuntimeException('Request URI has not been set');
         }
 
-        if (isset($options['fragment']) && is_string($options['fragment'])) {
-            $uri->setFragment($options['fragment']);
+        $query    = $assembledUrl->query;
+        $fragment = $assembledUrl->fragment;
+
+        if (array_key_exists('query', $options) && is_array($options['query'])) {
+            $query = $options['query'];
         }
 
-        if (
-            (isset($options['force_canonical'])
-            && $options['force_canonical'] === true)
-            || $uri->getHost() !== null
-            || $uri->getScheme() !== null
-        ) {
-            if (($uri->getHost() === null || $uri->getScheme() === null) && $this->requestUri === null) {
-                throw new Exception\RuntimeException('Request URI has not been set');
-            }
-
-            if ($uri->getHost() === null && $this->requestUri !== null) {
-                $uri->setHost($this->requestUri->getHost());
-            }
-
-            if ($uri->getScheme() === null && $this->requestUri !== null) {
-                $uri->setScheme($this->requestUri->getScheme());
-            }
-
-            $uri->setPath($path);
-
-            if (! isset($options['normalize_path']) || $options['normalize_path'] === true) {
-                $uri->normalize();
-            }
-
-            return $uri->toString();
-        } elseif (! $uri->isAbsolute() && $uri->isValidRelative()) {
-            $uri->setPath($path);
-
-            if (! isset($options['normalize_path']) || $options['normalize_path'] === true) {
-                $uri->normalize();
-            }
-
-            return $uri->toString();
+        if (array_key_exists('fragment', $options) && is_string($options['fragment'])) {
+            $fragment = $options['fragment'];
         }
 
-        return $path;
+        return new AssembledUrl(
+            $assembledUrl->path,
+            $query,
+            $resolvedHost,
+            $resolvedScheme,
+            $fragment,
+            $forceCanonical || $assembledUrl->host !== null || $assembledUrl->scheme !== null,
+            $resolvedPort,
+        );
     }
 
-    /**
-     * Set the base URL.
-     */
-    public function setBaseUrl(string $baseUrl): void
+    #[Override]
+    public function getPriority(): ?int
     {
-        $this->baseUrl = rtrim($baseUrl, '/');
-    }
-
-    /**
-     * Get the base URL.
-     */
-    public function getBaseUrl(): ?string
-    {
-        return $this->baseUrl;
+        return $this->priority;
     }
 
     /**
      * Set the request URI.
      */
-    public function setRequestUri(HttpUri $uri): void
+    public function setRequestUri(UriInterface $uri): void
     {
         $this->requestUri = $uri;
     }
@@ -377,7 +306,7 @@ class TreeRouteStack extends SimpleRouteStack
     /**
      * Get the request URI.
      */
-    public function getRequestUri(): ?HttpUri
+    public function getRequestUri(): ?UriInterface
     {
         return $this->requestUri;
     }

--- a/src/Http/TreeRouteStack.php
+++ b/src/Http/TreeRouteStack.php
@@ -83,7 +83,7 @@ class TreeRouteStack extends SimpleRouteStack
     {
         if ($route instanceof RouteInterface && ! $route instanceof HttpRouteInterface) {
             throw new Exception\InvalidArgumentException(
-                'Only HttpRouteInterface instances or array/string specifications are allowed.'
+                'Only HttpRouteInterface instances or array specifications are allowed.'
             );
         }
         if (is_array($route)) {
@@ -271,6 +271,7 @@ class TreeRouteStack extends SimpleRouteStack
         $fragment = $assembledUrl->fragment;
 
         if (array_key_exists('query', $options) && is_array($options['query'])) {
+            /** @var array<string, scalar> $query */
             $query = $options['query'];
         }
 

--- a/src/PriorityList.php
+++ b/src/PriorityList.php
@@ -12,7 +12,7 @@ use Laminas\Stdlib\PriorityList as StdlibPriorityList;
  * @psalm-internal \Laminas\Router
  * @psalm-internal \LaminasTest\Router
  *
- * @template TKey of non-empty-string|array-key
+ * @template TKey of non-empty-string
  * @template TValue of RouteInterface
  * @template-extends StdlibPriorityList<TKey, TValue>
  */

--- a/src/RouteInterface.php
+++ b/src/RouteInterface.php
@@ -4,20 +4,14 @@ declare(strict_types=1);
 
 namespace Laminas\Router;
 
-use Laminas\Stdlib\RequestInterface;
+use Laminas\Router\AssembledUrl;
+use Psr\Http\Message\RequestInterface;
 
 /**
  * RouteInterface interface.
  */
 interface RouteInterface
 {
-    /**
-     * Priority used for route stacks.
-     *
-     * @var int
-     * public int|null $priority = null;
-     */
-
     /**
      * Create a new route with given options.
      */
@@ -33,5 +27,7 @@ interface RouteInterface
      *
      * @param array<non-empty-string, string|null|int|float> $params
      */
-    public function assemble(array $params = [], array $options = []): string;
+    public function assemble(array $params = [], array $options = []): AssembledUrl;
+
+    public function getPriority(): int|null;
 }

--- a/src/RouteInvokableFactory.php
+++ b/src/RouteInvokableFactory.php
@@ -23,7 +23,7 @@ use function sprintf;
  * @psalm-internal \Laminas\Router
  * @psalm-internal \LaminasTest\Router
  */
-final class RouteInvokableFactory implements AbstractFactoryInterface
+final readonly class RouteInvokableFactory implements AbstractFactoryInterface
 {
     /**
      * Can we create a route instance with the given name? (v3)

--- a/src/RoutePluginManager.php
+++ b/src/RoutePluginManager.php
@@ -151,8 +151,7 @@ final class RoutePluginManager extends AbstractPluginManager
             unset($config['invokables']);
         }
 
-        // phpcs:disable SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.MissingVariable
-        /** @var ServiceManagerConfiguration $config */
+        /** @psalm-var ServiceManagerConfiguration $config */
         parent::configure($config);
 
         return $this;

--- a/src/RoutePluginManagerFactory.php
+++ b/src/RoutePluginManagerFactory.php
@@ -16,7 +16,7 @@ use Psr\Container\ContainerInterface;
  *
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
  */
-final class RoutePluginManagerFactory implements FactoryInterface
+final readonly class RoutePluginManagerFactory implements FactoryInterface
 {
     /**
      * Create and return a route plugin manager.

--- a/src/RouteStackInterface.php
+++ b/src/RouteStackInterface.php
@@ -12,10 +12,10 @@ interface RouteStackInterface extends RouteInterface
     /**
      * Add a route to the stack.
      *
-     * @param non-empty-string|array-key $name
+     * @param non-empty-string $name
      * @param array|TRoute $route
      */
-    public function addRoute(string|int $name, array|RouteInterface $route, ?int $priority = null): void;
+    public function addRoute(string $name, array|RouteInterface $route, ?int $priority = null): void;
 
     /**
      * Add multiple routes to the stack.

--- a/src/RouterFactory.php
+++ b/src/RouterFactory.php
@@ -14,7 +14,7 @@ use Psr\Container\ContainerInterface;
  * @psalm-internal \Laminas\Router
  * @psalm-internal \LaminasTest\Router
  */
-final class RouterFactory implements FactoryInterface
+final readonly class RouterFactory implements FactoryInterface
 {
     /**
      * Create and return the router

--- a/src/SimpleRouteStack.php
+++ b/src/SimpleRouteStack.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Laminas\Router;
 
+use Laminas\Router\AssembledUrl;
 use Laminas\Router\Exception\RuntimeException;
 use Laminas\Router\PriorityList;
 use Laminas\Router\RouteMatch;
-use Laminas\Stdlib\RequestInterface;
 use Override;
+use Psr\Http\Message\RequestInterface;
 
 use function array_merge;
 use function assert;
@@ -22,13 +23,14 @@ use function sprintf;
  *
  * @template TRoute of RouteInterface
  * @template-implements RouteStackInterface<TRoute>
+ * @psalm-consistent-constructor
  */
 class SimpleRouteStack implements RouteStackInterface
 {
     /**
      * Stack containing all routes.
      *
-     * @var PriorityList<non-empty-string|array-key, TRoute>
+     * @var PriorityList<non-empty-string, TRoute>
      */
     protected PriorityList $routes;
 
@@ -44,7 +46,7 @@ class SimpleRouteStack implements RouteStackInterface
          */
         protected array $defaultParams = []
     ) {
-        /** @var PriorityList<non-empty-string|array-key, TRoute> $priorityList */
+        /** @var PriorityList<non-empty-string, TRoute> $priorityList */
         $priorityList = new PriorityList();
         $this->routes = $priorityList;
         $this->addRoutes($routes);
@@ -66,7 +68,6 @@ class SimpleRouteStack implements RouteStackInterface
         if (! $routePlugins instanceof RoutePluginManager) {
             throw new RuntimeException('Missing "route_plugins" in options array');
         }
-
         return new static(
             $routePlugins,
             $routes,
@@ -79,25 +80,27 @@ class SimpleRouteStack implements RouteStackInterface
     public function addRoutes(array $routes): void
     {
         foreach ($routes as $name => $route) {
+            $name = is_int($name) ? (string) $name : $name;
+            assert($name !== '');
             $this->addRoute($name, $route);
         }
     }
 
     /** @inheritDoc */
     #[Override]
-    public function addRoute(string|int $name, array|RouteInterface $route, ?int $priority = null): void
+    public function addRoute(string $name, array|RouteInterface $route, ?int $priority = null): void
     {
         if (is_array($route)) {
             $route = $this->routeFromArray($route);
         }
 
-        if ($priority === null && isset($route->priority) && is_int($route->priority)) {
-            $priority = $route->priority;
+        $routePriority = $route->getPriority();
+
+        if ($priority === null && $routePriority !== null) {
+            $priority = $routePriority;
         }
 
-        $priority ??= 0;
-
-        $this->routes->insert($name, $route, $priority);
+        $this->routes->insert($name, $route, $priority ?? 0);
     }
 
     /** @inheritDoc */
@@ -171,13 +174,8 @@ class SimpleRouteStack implements RouteStackInterface
             throw new Exception\InvalidArgumentException('Missing "type" option');
         }
 
-        $route = $this->routePluginManager->build($type, $option);
-
         /** @psalm-var TRoute $route */
-
-        if (isset($specs['priority'])) {
-            $route->priority = $specs['priority'];
-        }
+        $route = $this->routePluginManager->build($type, [...$option, 'priority' => $specs['priority'] ?? null]);
 
         return $route;
     }
@@ -187,11 +185,11 @@ class SimpleRouteStack implements RouteStackInterface
     public function match(RequestInterface $request): ?RouteMatch
     {
         foreach ($this->routes as $name => $route) {
-            assert($name !== "");
+            assert(is_string($name));
             assert($route instanceof RouteInterface);
             $match = $route->match($request);
             if ($match instanceof RouteMatch) {
-                $match->setMatchedRouteName((string) $name);
+                $match->setMatchedRouteName($name);
 
                 foreach ($this->defaultParams as $paramName => $value) {
                     if ($match->getParam($paramName) === null) {
@@ -206,13 +204,19 @@ class SimpleRouteStack implements RouteStackInterface
         return null;
     }
 
+    #[Override]
+    public function getPriority(): ?int
+    {
+        return null;
+    }
+
     /**
      * @inheritDoc
      * @throws Exception\InvalidArgumentException
      * @throws RuntimeException
      */
     #[Override]
-    public function assemble(array $params = [], array $options = []): string
+    public function assemble(array $params = [], array $options = []): AssembledUrl
     {
         $name = $options['name'] ?? null;
         if (! is_string($name) || $name === '') {
@@ -221,7 +225,7 @@ class SimpleRouteStack implements RouteStackInterface
 
         $route = $this->routes->get($name);
 
-        if (! $route) {
+        if (! $route instanceof RouteInterface) {
             throw new RuntimeException(sprintf('Route with name "%s" not found', $name));
         }
 

--- a/test/AssembledUrlTest.php
+++ b/test/AssembledUrlTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Router;
+
+use Laminas\Router\AssembledUrl;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class AssembledUrlTest extends TestCase
+{
+    public function testMergeCombinesPathQueryAndScalarProperties(): void
+    {
+        $base  = new AssembledUrl(
+            path: '/base',
+            query: ['keep' => 'a', 'override' => 'old'],
+            host: 'base.example',
+            scheme: 'http',
+            fragment: 'base',
+            forceCanonical: false,
+            port: 8080,
+        );
+        $other = new AssembledUrl(
+            path: '/other',
+            query: ['add' => 'b', 'override' => 'new'],
+            host: 'other.example',
+            scheme: 'https',
+            fragment: 'other',
+            forceCanonical: true,
+            port: 443,
+        );
+
+        $merged = $base->merge($other);
+
+        $this->assertSame('/base/other', $merged->path);
+        $this->assertSame(['keep' => 'a', 'override' => 'new', 'add' => 'b'], $merged->query);
+        $this->assertSame('other.example', $merged->host);
+        $this->assertSame('https', $merged->scheme);
+        $this->assertSame('other', $merged->fragment);
+        $this->assertTrue($merged->forceCanonical);
+        $this->assertSame(443, $merged->port);
+
+        $fallback = new AssembledUrl(path: '/x');
+        $merged   = $base->merge($fallback);
+
+        $this->assertSame('base.example', $merged->host);
+        $this->assertSame('http', $merged->scheme);
+        $this->assertSame('base', $merged->fragment);
+        $this->assertSame(8080, $merged->port);
+    }
+
+    public function testMergeForceCanonicalIsTrueWhenEitherSideIsTrue(): void
+    {
+        $false = new AssembledUrl(forceCanonical: false);
+        $true  = new AssembledUrl(forceCanonical: true);
+
+        $this->assertTrue($false->merge($true)->forceCanonical);
+        $this->assertTrue($true->merge($false)->forceCanonical);
+        $this->assertFalse($false->merge($false)->forceCanonical);
+    }
+
+    /**
+     * @param non-empty-string $scheme
+     */
+    #[DataProvider('defaultPortProvider')]
+    public function testToStringOmitsDefaultPorts(string $scheme, int $port, string $expected): void
+    {
+        $url = new AssembledUrl(
+            path: '/foo',
+            host: 'example.com',
+            scheme: $scheme,
+            forceCanonical: true,
+            port: $port,
+        );
+
+        $this->assertSame($expected, $url->toString());
+    }
+
+    /** @return iterable<non-empty-string, array{non-empty-string, int, string}> */
+    public static function defaultPortProvider(): iterable
+    {
+        yield 'http default port' => ['http', 80, 'http://example.com/foo'];
+        yield 'https default port' => ['https', 443, 'https://example.com/foo'];
+        yield 'uppercase http scheme' => ['HTTP', 80, 'HTTP://example.com/foo'];
+    }
+
+    /**
+     * @param non-empty-string $scheme
+     */
+    #[DataProvider('nonDefaultPortProvider')]
+    public function testToStringEmitsNonDefaultPorts(string $scheme, int $port, string $expected): void
+    {
+        $url = new AssembledUrl(
+            path: '/foo',
+            host: 'example.com',
+            scheme: $scheme,
+            forceCanonical: true,
+            port: $port,
+        );
+
+        $this->assertSame($expected, $url->toString());
+    }
+
+    /** @return iterable<non-empty-string, array{non-empty-string, int, string}> */
+    public static function nonDefaultPortProvider(): iterable
+    {
+        yield 'http non-default port' => ['http', 8080, 'http://example.com:8080/foo'];
+        yield 'https non-default port' => ['https', 8443, 'https://example.com:8443/foo'];
+    }
+}

--- a/test/Http/ChainTest.php
+++ b/test/Http/ChainTest.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace LaminasTest\Router\Http;
 
-use ArrayObject;
-use Laminas\Http\Request;
+use Laminas\Diactoros\Request;
+use Laminas\Diactoros\Uri;
 use Laminas\Router\Http\Chain;
-use Laminas\Router\Http\HttpRouteInterface;
 use Laminas\Router\Http\HttpRouteMatch;
 use Laminas\Router\Http\Segment;
 use Laminas\Router\RoutePluginManager;
@@ -24,12 +23,9 @@ final class ChainTest extends TestCase
     public static function getRoute(): Chain
     {
         $routePlugins = new RoutePluginManager(new ServiceManager());
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
 
         return new Chain(
             $routePlugins,
-            $prototypes,
             [
                 [
                     'type'    => Segment::class,
@@ -49,19 +45,16 @@ final class ChainTest extends TestCase
                         ],
                     ],
                 ],
-            ],
+            ]
         );
     }
 
     public static function getRouteWithOptionalParam(): Chain
     {
         $routePlugins = new RoutePluginManager(new ServiceManager());
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
 
         return new Chain(
             $routePlugins,
-            $prototypes,
             [
                 [
                     'type'    => Segment::class,
@@ -81,7 +74,7 @@ final class ChainTest extends TestCase
                         ],
                     ],
                 ],
-            ],
+            ]
         );
     }
 
@@ -151,8 +144,8 @@ final class ChainTest extends TestCase
     public function testMatching(Chain $route, string $path, int|null $offset, ?array $params = null): void
     {
         $request = new Request();
-        $request->setUri('http://example.com' . $path);
-        $match = $route->match($request, $offset);
+        $request = $request->withUri(new Uri('http://example.com' . $path));
+        $match   = $route->match($request, $offset);
 
         if ($params === null) {
             $this->assertNull($match);
@@ -183,7 +176,7 @@ final class ChainTest extends TestCase
         $result = $route->assemble($params);
 
         if ($offset !== null) {
-            $this->assertEquals($offset, strpos($path, $result, $offset));
+            $this->assertEquals($offset, strpos($path, (string) $result, $offset));
         } else {
             $this->assertEquals($path, $result);
         }

--- a/test/Http/ChainTest.php
+++ b/test/Http/ChainTest.php
@@ -182,6 +182,88 @@ final class ChainTest extends TestCase
         }
     }
 
+    public function testMatchRejectsTrailingPathWhenNoOffset(): void
+    {
+        $request = (new Request())->withUri(new Uri('http://example.com/foo/bar/extra'));
+
+        $this->assertNull(self::getRoute()->match($request));
+    }
+
+    public function testMatchWithZeroOffsetAllowsPartialPath(): void
+    {
+        $request = (new Request())->withUri(new Uri('http://example.com/foo/bar/extra'));
+
+        $this->assertInstanceOf(HttpRouteMatch::class, self::getRoute()->match($request, 0));
+    }
+
+    public function testAssemblingOmitsOptionalTrailingSegmentWithoutParam(): void
+    {
+        $this->assertSame(
+            '/foo',
+            self::getRouteWithOptionalParam()->assemble(['controller' => 'foo'])->toString()
+        );
+    }
+
+    public function testAssemblingPropagatesHasChildOptionToLastSegment(): void
+    {
+        $routePlugins = new RoutePluginManager(new ServiceManager());
+        $route        = new Chain(
+            $routePlugins,
+            [
+                [
+                    'type'    => Segment::class,
+                    'options' => [
+                        'route'    => '/:controller',
+                        'defaults' => ['controller' => 'foo'],
+                    ],
+                ],
+                [
+                    'type'    => Segment::class,
+                    'options' => [
+                        'route'    => '[/:bar]',
+                        'defaults' => ['bar' => 'bar'],
+                    ],
+                ],
+            ]
+        );
+
+        $this->assertSame('/foo/bar', $route->assemble([], ['has_child' => true])->toString());
+    }
+
+    public function testAssemblingStripsConsumedParamsBetweenSegments(): void
+    {
+        $routePlugins = new RoutePluginManager(new ServiceManager());
+        $route        = new Chain(
+            $routePlugins,
+            [
+                [
+                    'type'    => Segment::class,
+                    'options' => [
+                        'route'    => '/:id',
+                        'defaults' => ['id' => '1'],
+                    ],
+                ],
+                [
+                    'type'    => Segment::class,
+                    'options' => [
+                        'route'    => '/:id',
+                        'defaults' => ['id' => '2'],
+                    ],
+                ],
+            ]
+        );
+
+        $this->assertSame('/x/2', $route->assemble(['id' => 'x'])->toString());
+    }
+
+    public function testGetAssembledParams(): void
+    {
+        $route = self::getRoute();
+        $route->assemble(['controller' => 'foo', 'bar' => 'baz']);
+
+        $this->assertSame(['controller', 'bar'], $route->getAssembledParams());
+    }
+
     public function testFactory(): void
     {
         $tester = new FactoryTester();

--- a/test/Http/ChainTest.php
+++ b/test/Http/ChainTest.php
@@ -176,9 +176,9 @@ final class ChainTest extends TestCase
         $result = $route->assemble($params);
 
         if ($offset !== null) {
-            $this->assertEquals($offset, strpos($path, (string) $result, $offset));
+            $this->assertEquals($offset, strpos($path, $result->toString(), $offset));
         } else {
-            $this->assertEquals($path, $result);
+            $this->assertEquals($path, $result->toString());
         }
     }
 

--- a/test/Http/HostnameTest.php
+++ b/test/Http/HostnameTest.php
@@ -200,7 +200,7 @@ final class HostnameTest extends TestCase
         $uri    = new Uri();
         $result = $route->assemble($params, ['uri' => $uri]);
 
-        $this->assertEquals('', (string) $result);
+        $this->assertEquals('', $result->toString());
         $this->assertSame($hostname, $result->host);
     }
 

--- a/test/Http/HostnameTest.php
+++ b/test/Http/HostnameTest.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace LaminasTest\Router\Http;
 
-use Laminas\Http\Request;
+use Laminas\Diactoros\Request;
+use Laminas\Diactoros\Uri;
 use Laminas\Router\Exception\InvalidArgumentException;
 use Laminas\Router\Exception\RuntimeException;
 use Laminas\Router\Http\Hostname;
 use Laminas\Router\Http\HttpRouteMatch;
-use Laminas\Stdlib\Request as BaseRequest;
-use Laminas\Uri\Http as HttpUri;
 use LaminasTest\Router\FactoryTester;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -172,8 +171,8 @@ final class HostnameTest extends TestCase
     public function testMatching(Hostname $route, string $hostname, ?array $params = null): void
     {
         $request = new Request();
-        $request->setUri('http://' . $hostname . '/');
-        $match = $route->match($request);
+        $request = $request->withUri(new Uri('http://' . $hostname . '/'));
+        $match   = $route->match($request);
 
         if ($params === null) {
             $this->assertNull($match);
@@ -198,17 +197,17 @@ final class HostnameTest extends TestCase
             return;
         }
 
-        $uri  = new HttpUri();
-        $path = $route->assemble($params, ['uri' => $uri]);
+        $uri    = new Uri();
+        $result = $route->assemble($params, ['uri' => $uri]);
 
-        $this->assertEquals('', $path);
-        $this->assertEquals($hostname, $uri->getHost());
+        $this->assertEquals('', (string) $result);
+        $this->assertSame($hostname, $result->host);
     }
 
     public function testNoMatchWithoutUriMethod(): void
     {
         $route   = new Hostname('example.com');
-        $request = new BaseRequest();
+        $request = new Request();
 
         $this->assertNull($route->match($request));
     }
@@ -217,7 +216,7 @@ final class HostnameTest extends TestCase
     {
         $route   = new Hostname('example.com');
         $request = new Request();
-        $request->setUri('/relative/path');
+        $request = $request->withUri(new Uri('/relative/path'));
 
         self::assertNull($route->match($request));
     }
@@ -226,7 +225,7 @@ final class HostnameTest extends TestCase
     {
         $route   = new Hostname(':domain');
         $request = new Request();
-        $request->setUri('/relative/path');
+        $request = $request->withUri(new Uri('/relative/path'));
 
         self::assertNull($route->match($request));
     }
@@ -235,7 +234,7 @@ final class HostnameTest extends TestCase
     {
         $route   = new Hostname('[:domain]');
         $request = new Request();
-        $request->setUri('/relative/path');
+        $request = $request->withUri(new Uri('/relative/path'));
 
         $match = $route->match($request);
         self::assertInstanceOf(HttpRouteMatch::class, $match);
@@ -245,7 +244,7 @@ final class HostnameTest extends TestCase
     public function testAssemblingWithMissingParameter(): void
     {
         $route = new Hostname(':foo.example.com');
-        $uri   = new HttpUri();
+        $uri   = new Uri();
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Missing parameter "foo"');
@@ -255,7 +254,7 @@ final class HostnameTest extends TestCase
     public function testGetAssembledParams(): void
     {
         $route = new Hostname(':foo.example.com');
-        $uri   = new HttpUri();
+        $uri   = new Uri();
         $route->assemble(['foo' => 'bar', 'baz' => 'bat'], ['uri' => $uri]);
 
         $this->assertEquals(['foo'], $route->getAssembledParams());

--- a/test/Http/HostnameTest.php
+++ b/test/Http/HostnameTest.php
@@ -14,6 +14,7 @@ use LaminasTest\Router\FactoryTester;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Throwable;
 
 final class HostnameTest extends TestCase
 {
@@ -258,6 +259,147 @@ final class HostnameTest extends TestCase
         $route->assemble(['foo' => 'bar', 'baz' => 'bat'], ['uri' => $uri]);
 
         $this->assertEquals(['foo'], $route->getAssembledParams());
+    }
+
+    public function testMatchIncludesDefaultsNotCapturedInHostname(): void
+    {
+        $route   = new Hostname('www.example.com', [], ['env' => 'prod']);
+        $request = (new Request())->withUri(new Uri('http://www.example.com/'));
+        $match   = $route->match($request);
+
+        $this->assertInstanceOf(HttpRouteMatch::class, $match);
+        $this->assertSame('prod', $match->getParam('env'));
+    }
+
+    public function testAssembleUsesDefaultsWhenParameterMissing(): void
+    {
+        $route  = new Hostname(':foo.example.com', [], ['foo' => 'baz']);
+        $result = $route->assemble([]);
+
+        $this->assertSame('baz.example.com', $result->host);
+    }
+
+    public function testAssembleOmitsOptionalWhenParameterEqualsDefault(): void
+    {
+        $route = new Hostname('[:foo.]example.com', [], ['foo' => 'bar']);
+
+        $this->assertSame('example.com', $route->assemble([])->host);
+        $this->assertSame('example.com', $route->assemble(['foo' => 'bar'])->host);
+    }
+
+    public function testAssembleIncludesOptionalWhenParameterDiffersFromDefault(): void
+    {
+        $route = new Hostname('[:foo.]example.com', [], ['foo' => 'bar']);
+
+        $this->assertSame('baz.example.com', $route->assemble(['foo' => 'baz'])->host);
+    }
+
+    public function testAssembleOmitsNestedOptionalWhenAllParametersEqualDefaults(): void
+    {
+        $route = new Hostname(
+            '[[:foo.]:bar.]example.com',
+            [],
+            ['foo' => 'a', 'bar' => 'b'],
+        );
+
+        $this->assertSame('example.com', $route->assemble([])->host);
+    }
+
+    public function testAssembleIncludesNestedOptionalWhenInnerParameterDiffersFromDefault(): void
+    {
+        $route = new Hostname(
+            '[[:foo.]:bar.]example.com',
+            [],
+            ['foo' => 'a', 'bar' => 'b'],
+        );
+
+        $this->assertSame('x.b.example.com', $route->assemble(['foo' => 'x'])->host);
+    }
+
+    public function testMatchCapturesThreeParametersInOrder(): void
+    {
+        $route   = new Hostname(':one.:two.:three.example.com');
+        $request = (new Request())->withUri(new Uri('http://a.b.c.example.com/'));
+        $match   = $route->match($request);
+
+        $this->assertInstanceOf(HttpRouteMatch::class, $match);
+        $this->assertSame('a', $match->getParam('one'));
+        $this->assertSame('b', $match->getParam('two'));
+        $this->assertSame('c', $match->getParam('three'));
+
+        $route->assemble(['one' => 'a', 'two' => 'b', 'three' => 'c']);
+        $this->assertSame(['one', 'two', 'three'], $route->getAssembledParams());
+    }
+
+    public function testConstructWithEmptyRoute(): void
+    {
+        $route   = new Hostname('');
+        $request = (new Request())->withUri((new Uri())->withHost(''));
+        $match   = $route->match($request);
+
+        $this->assertInstanceOf(HttpRouteMatch::class, $match);
+        $this->assertSame('', $route->assemble([])->host ?? '');
+    }
+
+    /**
+     * @psalm-return array<string, array{0: string, 1: class-string<Throwable>, 2: string}>
+     */
+    public static function parseExceptionsProvider(): array
+    {
+        return [
+            'unbalanced-brackets'     => [
+                '[',
+                RuntimeException::class,
+                'Found unbalanced brackets',
+            ],
+            'closing-without-opening' => [
+                ']',
+                RuntimeException::class,
+                'Found closing bracket without matching opening bracket',
+            ],
+            'empty-parameter-name'    => [
+                ':',
+                RuntimeException::class,
+                'Found empty parameter name',
+            ],
+        ];
+    }
+
+    /**
+     * @param class-string<Throwable> $exception
+     */
+    #[DataProvider('parseExceptionsProvider')]
+    public function testParseRouteDefinitionExceptions(string $route, string $exception, string $message): void
+    {
+        $this->expectException($exception);
+        $this->expectExceptionMessage($message);
+        new Hostname($route);
+    }
+
+    public function testFactoryAppliesConstraintsDefaultsAndPriority(): void
+    {
+        $route = Hostname::factory([
+            'route'       => ':foo.example.com',
+            'constraints' => ['foo' => '\d+'],
+            'defaults'    => ['foo' => '999'],
+            'priority'    => 5,
+        ]);
+
+        $this->assertSame(5, $route->getPriority());
+        $this->assertSame(
+            '999.example.com',
+            $route->assemble([])->host
+        );
+
+        $match = $route->match(
+            (new Request())->withUri(new Uri('http://123.example.com/'))
+        );
+        $this->assertInstanceOf(HttpRouteMatch::class, $match);
+        $this->assertSame('123', $match->getParam('foo'));
+
+        $this->assertNull(
+            $route->match((new Request())->withUri(new Uri('http://abc.example.com/')))
+        );
     }
 
     public function testFactory(): void

--- a/test/Http/LiteralTest.php
+++ b/test/Http/LiteralTest.php
@@ -92,9 +92,9 @@ final class LiteralTest extends TestCase
         $result = $route->assemble();
 
         if ($offset !== null) {
-            $this->assertEquals($offset, strpos($path, (string) $result, $offset));
+            $this->assertEquals($offset, strpos($path, $result->toString(), $offset));
         } else {
-            $this->assertEquals($path, $result);
+            $this->assertEquals($path, $result->toString());
         }
     }
 

--- a/test/Http/LiteralTest.php
+++ b/test/Http/LiteralTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace LaminasTest\Router\Http;
 
-use Laminas\Http\Request;
+use Laminas\Diactoros\Request;
+use Laminas\Diactoros\Uri;
 use Laminas\Router\Http\HttpRouteMatch;
 use Laminas\Router\Http\Literal;
-use Laminas\Stdlib\Request as BaseRequest;
 use LaminasTest\Router\FactoryTester;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -66,8 +66,8 @@ final class LiteralTest extends TestCase
     public function testMatching(Literal $route, string $path, int|null $offset, bool $shouldMatch): void
     {
         $request = new Request();
-        $request->setUri('http://example.com' . $path);
-        $match = $route->match($request, $offset);
+        $request = $request->withUri(new Uri('http://example.com' . $path));
+        $match   = $route->match($request, $offset);
 
         if (! $shouldMatch) {
             $this->assertNull($match);
@@ -92,7 +92,7 @@ final class LiteralTest extends TestCase
         $result = $route->assemble();
 
         if ($offset !== null) {
-            $this->assertEquals($offset, strpos($path, $result, $offset));
+            $this->assertEquals($offset, strpos($path, (string) $result, $offset));
         } else {
             $this->assertEquals($path, $result);
         }
@@ -101,7 +101,7 @@ final class LiteralTest extends TestCase
     public function testNoMatchWithoutUriMethod(): void
     {
         $route   = new Literal('/foo');
-        $request = new BaseRequest();
+        $request = new Request();
 
         $this->assertNull($route->match($request));
     }

--- a/test/Http/LiteralTest.php
+++ b/test/Http/LiteralTest.php
@@ -135,4 +135,50 @@ final class LiteralTest extends TestCase
         $route   = new Literal('');
         $this->assertNull($route->match($request, 0));
     }
+
+    public function testMatchWithOffsetBeyondPathLengthReturnsNull(): void
+    {
+        $request = (new Request())->withUri(new Uri('http://example.com/foo'));
+
+        $this->assertNull((new Literal('/foo'))->match($request, 10));
+    }
+
+    public function testMatchWithNegativeOffsetReturnsNull(): void
+    {
+        $request = (new Request())->withUri(new Uri('http://example.com/foo'));
+
+        $this->assertNull((new Literal('/foo'))->match($request, -1));
+    }
+
+    public function testMatchWithOffsetMisalignedReturnsNull(): void
+    {
+        $request = (new Request())->withUri(new Uri('http://example.com/x/foo'));
+
+        $this->assertNull((new Literal('foo'))->match($request, 1));
+    }
+
+    public function testMatchWithOffsetReturnsSegmentLength(): void
+    {
+        $request = (new Request())->withUri(new Uri('http://example.com/foo'));
+        $match   = (new Literal('foo'))->match($request, 1);
+
+        $this->assertInstanceOf(HttpRouteMatch::class, $match);
+        $this->assertSame(3, $match->getLength());
+    }
+
+    public function testMatchWithOffsetAtPathLengthReturnsNull(): void
+    {
+        $request = (new Request())->withUri(new Uri('http://example.com/foo'));
+
+        $this->assertNull((new Literal('/foo'))->match($request, 4));
+    }
+
+    public function testMatchWithOffsetEnablesMatchAtLastCharacter(): void
+    {
+        $request = (new Request())->withUri(new Uri('http://example.com/foo'));
+        $match   = (new Literal('o'))->match($request, 3);
+
+        $this->assertInstanceOf(HttpRouteMatch::class, $match);
+        $this->assertSame(1, $match->getLength());
+    }
 }

--- a/test/Http/MethodTest.php
+++ b/test/Http/MethodTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace LaminasTest\Router\Http;
 
-use Laminas\Http\Request;
+use Laminas\Diactoros\Request;
+use Laminas\Diactoros\Uri;
 use Laminas\Router\Http\HttpRouteMatch;
 use Laminas\Router\Http\Method as HttpMethod;
-use Laminas\Stdlib\Request as BaseRequest;
 use LaminasTest\Router\FactoryTester;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -46,8 +46,8 @@ final class MethodTest extends TestCase
     public function testMatching(HttpMethod $route, string $verb): void
     {
         $request = new Request();
-        $request->setUri('http://example.com');
-        $request->setMethod($verb);
+        $request = $request->withUri(new Uri('http://example.com'));
+        $request = $request->withMethod($verb);
 
         $match = $route->match($request);
         $this->assertInstanceOf(HttpRouteMatch::class, $match);
@@ -56,7 +56,7 @@ final class MethodTest extends TestCase
     public function testNoMatchWithoutVerb(): void
     {
         $route   = new HttpMethod('get');
-        $request = new BaseRequest();
+        $request = (new Request())->withMethod('POST');
 
         $this->assertNull($route->match($request));
     }

--- a/test/Http/PartTest.php
+++ b/test/Http/PartTest.php
@@ -251,9 +251,9 @@ final class PartTest extends TestCase
         $result = $route->assemble($params, ['name' => $routeName]);
 
         if ($offset !== null) {
-            $this->assertEquals($offset, strpos($path, (string) $result, $offset));
+            $this->assertEquals($offset, strpos($path, $result->toString(), $offset));
         } else {
-            $this->assertEquals($path, (string) $result);
+            $this->assertEquals($path, $result->toString());
         }
     }
 

--- a/test/Http/PartTest.php
+++ b/test/Http/PartTest.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace LaminasTest\Router\Http;
 
-use ArrayObject;
-use Laminas\Http\Request;
+use Laminas\Diactoros\Request;
+use Laminas\Diactoros\Uri;
 use Laminas\Router\Exception\InvalidArgumentException;
 use Laminas\Router\Exception\RuntimeException;
-use Laminas\Router\Http\HttpRouteInterface;
 use Laminas\Router\Http\HttpRouteMatch;
 use Laminas\Router\Http\Literal;
 use Laminas\Router\Http\Part;
@@ -17,8 +16,6 @@ use Laminas\Router\RouteInvokableFactory;
 use Laminas\Router\RouteMatch;
 use Laminas\Router\RoutePluginManager;
 use Laminas\ServiceManager\ServiceManager;
-use Laminas\Stdlib\Parameters;
-use Laminas\Stdlib\Request as BaseRequest;
 use LaminasTest\Router\FactoryTester;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -50,12 +47,8 @@ final class PartTest extends TestCase
 
     public static function getRoute(): Part
     {
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-
         return new Part(
             self::getRoutePlugins(),
-            $prototypes,
             [
                 'type'    => Literal::class,
                 'options' => [
@@ -66,6 +59,7 @@ final class PartTest extends TestCase
                 ],
             ],
             [],
+            null,
             true,
             [
                 'bar' => [
@@ -116,7 +110,7 @@ final class PartTest extends TestCase
                         ],
                     ],
                 ],
-            ],
+            ]
         );
     }
 
@@ -217,8 +211,8 @@ final class PartTest extends TestCase
         ?array $params = null
     ): void {
         $request = new Request();
-        $request->setUri('http://example.com' . $path);
-        $match = $route->match($request, $offset);
+        $request = $request->withUri(new Uri('http://example.com' . $path));
+        $match   = $route->match($request, $offset);
 
         if ($params === null) {
             $this->assertNull($match);
@@ -257,9 +251,9 @@ final class PartTest extends TestCase
         $result = $route->assemble($params, ['name' => $routeName]);
 
         if ($offset !== null) {
-            $this->assertEquals($offset, strpos($path, $result, $offset));
+            $this->assertEquals($offset, strpos($path, (string) $result, $offset));
         } else {
-            $this->assertEquals($path, $result);
+            $this->assertEquals($path, (string) $result);
         }
     }
 
@@ -275,23 +269,19 @@ final class PartTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Base route may not be a part route');
 
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-
         new Part(
             new RoutePluginManager(new ServiceManager()),
-            $prototypes,
             self::getRoute(),
             [],
-            true,
-            [],
+            null,
+            true
         );
     }
 
     public function testNoMatchWithoutUriMethod(): void
     {
         $route   = self::getRoute();
-        $request = new BaseRequest();
+        $request = new Request();
 
         $this->assertNull($route->match($request));
     }
@@ -351,10 +341,9 @@ final class PartTest extends TestCase
 
         $route   = Part::factory($options);
         $request = new Request();
-        $request->setUri('http://example.com/resource?foo=bar');
-        $query = new Parameters(['foo' => 'bar']);
-        $request->setQuery($query);
-        $request->getQuery();
+        $uri     = new Uri('http://example.com/resource?foo=bar');
+        $uri     = $uri->withQuery('foo');
+        $request = $request->withUri($uri);
 
         $match = $route->match($request);
         $this->assertInstanceOf(RouteMatch::class, $match);

--- a/test/Http/PartTest.php
+++ b/test/Http/PartTest.php
@@ -16,10 +16,13 @@ use Laminas\Router\RouteInvokableFactory;
 use Laminas\Router\RouteMatch;
 use Laminas\Router\RoutePluginManager;
 use Laminas\ServiceManager\ServiceManager;
+use Laminas\Translator\TranslatorInterface;
 use LaminasTest\Router\FactoryTester;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
 
 use function strlen;
 use function strpos;
@@ -348,5 +351,153 @@ final class PartTest extends TestCase
         $match = $route->match($request);
         $this->assertInstanceOf(RouteMatch::class, $match);
         $this->assertEquals('resource', $match->getParam('action'));
+    }
+
+    private function getLocalePartRoute(): Part
+    {
+        return new Part(
+            self::getRoutePlugins(),
+            [
+                'type'    => Segment::class,
+                'options' => [
+                    'route' => '/:locale',
+                ],
+            ],
+            [],
+            null,
+            true,
+            [
+                'index' => [
+                    'type'    => Segment::class,
+                    'options' => [
+                        'route' => '/{homepage}',
+                    ],
+                ],
+            ],
+        );
+    }
+
+    private function getTranslator(int $expectedCallCount): TranslatorInterface&MockObject
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->expects($this->exactly($expectedCallCount))
+            ->method('translate')
+            ->willReturnCallback(function (
+                string $message,
+                string $textDomain = 'default',
+                ?string $locale = null
+            ): string {
+                if ($message === 'homepage' && $textDomain === 'route' && $locale === 'de') {
+                    return 'hauptseite';
+                }
+
+                if ($message === 'homepage' && $textDomain === 'route' && $locale === 'en') {
+                    return 'homepage';
+                }
+
+                throw new UnexpectedValueException('Translation not found');
+            });
+
+        return $translator;
+    }
+
+    public function testMatchPropagatesLocaleFromParentParam(): void
+    {
+        $route   = $this->getLocalePartRoute();
+        $request = (new Request())->withUri(new Uri('http://example.com/de/hauptseite'));
+
+        $match = $route->match($request, null, ['translator' => $this->getTranslator(1), 'text_domain' => 'route']);
+
+        $this->assertInstanceOf(HttpRouteMatch::class, $match);
+        $this->assertSame('index', $match->getMatchedRouteName());
+    }
+
+    public function testAssemblePropagatesLocaleFromParamsWhenLocaleOptionIsNotSet(): void
+    {
+        $route = $this->getLocalePartRoute();
+
+        $this->assertSame(
+            '/de/hauptseite',
+            $route->assemble(
+                ['locale' => 'de'],
+                ['name' => 'index', 'translator' => $this->getTranslator(1), 'text_domain' => 'route']
+            )->toString()
+        );
+    }
+
+    public function testAssembleDoesNotPropagateLocaleWhenLocaleOptionIsSet(): void
+    {
+        $route = $this->getLocalePartRoute();
+
+        $this->assertSame(
+            '/de/homepage',
+            $route->assemble(
+                ['locale' => 'de'],
+                [
+                    'name'        => 'index',
+                    'locale'      => 'en',
+                    'translator'  => $this->getTranslator(1),
+                    'text_domain' => 'route',
+                ]
+            )->toString()
+        );
+    }
+
+    public function testMatchDoesNotPropagateLocaleWhenLocaleOptionIsSet(): void
+    {
+        $route   = $this->getLocalePartRoute();
+        $request = (new Request())->withUri(new Uri('http://example.com/de/hauptseite'));
+
+        $match = $route->match($request, null, [
+            'translator'  => $this->getTranslator(1),
+            'text_domain' => 'route',
+            'locale'      => 'en',
+        ]);
+
+        $this->assertNull($match);
+    }
+
+    public function testAssembleStripsParentAssembledParams(): void
+    {
+        $route = new Part(
+            self::getRoutePlugins(),
+            [
+                'type'    => Segment::class,
+                'options' => [
+                    'route' => '/:foo',
+                ],
+            ],
+            [],
+            null,
+            true,
+            [
+                'bar' => [
+                    'type'    => Segment::class,
+                    'options' => [
+                        'route'    => '/:foo/baz',
+                        'defaults' => ['foo' => '2'],
+                    ],
+                ],
+            ],
+        );
+
+        $this->assertSame('/1/2/baz', $route->assemble(['foo' => '1'], ['name' => 'bar'])->toString());
+    }
+
+    public function testAssembleChildReturnsPathOnly(): void
+    {
+        $route = self::getRoute();
+
+        $this->assertSame(
+            '/foo/bar',
+            $route->assemble(
+                ['controller' => 'bar'],
+                [
+                    'name'            => 'bar',
+                    'uri'             => new Uri('https://example.com'),
+                    'force_canonical' => true,
+                ]
+            )->toString()
+        );
     }
 }

--- a/test/Http/PlaceholderTest.php
+++ b/test/Http/PlaceholderTest.php
@@ -62,7 +62,7 @@ final class PlaceholderTest extends TestCase
     public function testAssembling(): void
     {
         $route = new Placeholder([]);
-        $this->assertEquals('', $route->assemble());
+        $this->assertEquals('', $route->assemble()->toString());
     }
 
     public function testGetAssembledParams(): void

--- a/test/Http/PlaceholderTest.php
+++ b/test/Http/PlaceholderTest.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace LaminasTest\Router\Http;
 
-use Laminas\Http\Request;
+use Laminas\Diactoros\Request;
+use Laminas\Diactoros\Uri;
 use Laminas\Router\Http\Hostname;
 use Laminas\Router\Http\HttpRouteMatch;
 use Laminas\Router\Http\Literal;
@@ -52,8 +53,8 @@ final class PlaceholderTest extends TestCase
         $route = new Placeholder([]);
 
         $request = new Request();
-        $request->setUri('http://example.com/');
-        $match = $route->match($request);
+        $request = $request->withUri(new Uri('http://example.com/'));
+        $match   = $route->match($request);
 
         $this->assertInstanceOf(HttpRouteMatch::class, $match);
     }
@@ -86,8 +87,8 @@ final class PlaceholderTest extends TestCase
         ]);
 
         $request = new Request();
-        $request->setUri($uri);
-        $match = $router->match($request);
+        $request = $request->withUri(new Uri($uri));
+        $match   = $router->match($request);
 
         $this->assertInstanceOf(HttpRouteMatch::class, $match);
         $this->assertEquals($expectedRouteName, $match->getMatchedRouteName());

--- a/test/Http/RegexTest.php
+++ b/test/Http/RegexTest.php
@@ -119,9 +119,9 @@ final class RegexTest extends TestCase
         $result = $route->assemble($params);
 
         if ($offset !== null) {
-            $this->assertEquals($offset, strpos($path, (string) $result, $offset));
+            $this->assertEquals($offset, strpos($path, $result->toString(), $offset));
         } else {
-            $this->assertEquals($path, (string) $result);
+            $this->assertEquals($path, $result->toString());
         }
     }
 

--- a/test/Http/RegexTest.php
+++ b/test/Http/RegexTest.php
@@ -141,6 +141,20 @@ final class RegexTest extends TestCase
         $this->assertEquals(['foo'], $route->getAssembledParams());
     }
 
+    public function testAssemblingUsesDefaultsForMissingParams(): void
+    {
+        $route = new Regex('/foo', '/foo-%bar%', ['bar' => 'baz']);
+
+        $this->assertSame('/foo-baz', $route->assemble([])->toString());
+    }
+
+    public function testAssemblingParamsOverrideDefaults(): void
+    {
+        $route = new Regex('/foo', '/foo-%bar%', ['bar' => 'baz']);
+
+        $this->assertSame('/foo-qux', $route->assemble(['bar' => 'qux'])->toString());
+    }
+
     public function testFactory(): void
     {
         $tester = new FactoryTester();

--- a/test/Http/RegexTest.php
+++ b/test/Http/RegexTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace LaminasTest\Router\Http;
 
-use Laminas\Http\Request;
+use Laminas\Diactoros\Request;
+use Laminas\Diactoros\Uri;
 use Laminas\Router\Http\HttpRouteMatch;
 use Laminas\Router\Http\Regex;
-use Laminas\Stdlib\Request as BaseRequest;
 use LaminasTest\Router\FactoryTester;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -86,8 +86,8 @@ final class RegexTest extends TestCase
     public function testMatching(Regex $route, string $path, int|null $offset, ?array $params = null): void
     {
         $request = new Request();
-        $request->setUri('http://example.com' . $path);
-        $match = $route->match($request, $offset);
+        $request = $request->withUri(new Uri('http://example.com' . $path));
+        $match   = $route->match($request, $offset);
 
         if ($params === null) {
             $this->assertNull($match);
@@ -119,16 +119,16 @@ final class RegexTest extends TestCase
         $result = $route->assemble($params);
 
         if ($offset !== null) {
-            $this->assertEquals($offset, strpos($path, $result, $offset));
+            $this->assertEquals($offset, strpos($path, (string) $result, $offset));
         } else {
-            $this->assertEquals($path, $result);
+            $this->assertEquals($path, (string) $result);
         }
     }
 
     public function testNoMatchWithoutUriMethod(): void
     {
         $route   = new Regex('/foo', '/foo');
-        $request = new BaseRequest();
+        $request = new Request();
 
         $this->assertNull($route->match($request));
     }
@@ -163,9 +163,9 @@ final class RegexTest extends TestCase
         // this includes every character other than #, %, / and ?
         $raw     = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`-=[]\\;\',.~!@$^&*()_+{}|:"<>';
         $request = new Request();
-        $request->setUri('http://example.com/' . $raw);
-        $route = new Regex('/(?<foo>[^/]+)', '/%foo%');
-        $match = $route->match($request);
+        $request = $request->withUri(new Uri('http://example.com/' . $raw));
+        $route   = new Regex('/(?<foo>[^/]+)', '/%foo%');
+        $match   = $route->match($request);
 
         $this->assertNotNull($match);
         $this->assertSame($raw, $match->getParam('foo'));
@@ -180,9 +180,9 @@ final class RegexTest extends TestCase
         // @codingStandardsIgnoreEnd
 
         $request = new Request();
-        $request->setUri('http://example.com/' . $in);
-        $route = new Regex('/(?<foo>[^/]+)', '/%foo%');
-        $match = $route->match($request);
+        $request = $request->withUri(new Uri('http://example.com/' . $in));
+        $route   = new Regex('/(?<foo>[^/]+)', '/%foo%');
+        $match   = $route->match($request);
 
         $this->assertNotNull($match);
         $this->assertSame($out, $match->getParam('foo'));

--- a/test/Http/SchemeTest.php
+++ b/test/Http/SchemeTest.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace LaminasTest\Router\Http;
 
-use Laminas\Http\Request;
+use Laminas\Diactoros\Request;
+use Laminas\Diactoros\Uri;
 use Laminas\Router\Http\HttpRouteMatch;
 use Laminas\Router\Http\Scheme;
-use Laminas\Stdlib\Request as BaseRequest;
-use Laminas\Uri\Http as HttpUri;
 use LaminasTest\Router\FactoryTester;
 use PHPUnit\Framework\TestCase;
 
@@ -17,7 +16,7 @@ final class SchemeTest extends TestCase
     public function testMatching(): void
     {
         $request = new Request();
-        $request->setUri('https://example.com/');
+        $request = $request->withUri(new Uri('https://example.com/'));
 
         $route = new Scheme('https');
         $match = $route->match($request);
@@ -28,7 +27,7 @@ final class SchemeTest extends TestCase
     public function testNoMatchingOnDifferentScheme(): void
     {
         $request = new Request();
-        $request->setUri('http://example.com/');
+        $request = $request->withUri(new Uri('http://example.com/'));
 
         $route = new Scheme('https');
         $match = $route->match($request);
@@ -38,18 +37,18 @@ final class SchemeTest extends TestCase
 
     public function testAssembling(): void
     {
-        $uri   = new HttpUri();
-        $route = new Scheme('https');
-        $path  = $route->assemble([], ['uri' => $uri]);
+        $uri    = new Uri();
+        $route  = new Scheme('https');
+        $result = $route->assemble([], ['uri' => $uri]);
 
-        $this->assertEquals('', $path);
-        $this->assertEquals('https', $uri->getScheme());
+        $this->assertEquals('', (string) $result);
+        $this->assertSame('https', $result->scheme);
     }
 
     public function testNoMatchWithoutUriMethod(): void
     {
         $route   = new Scheme('https');
-        $request = new BaseRequest();
+        $request = new Request();
 
         $this->assertNull($route->match($request));
     }

--- a/test/Http/SchemeTest.php
+++ b/test/Http/SchemeTest.php
@@ -41,7 +41,7 @@ final class SchemeTest extends TestCase
         $route  = new Scheme('https');
         $result = $route->assemble([], ['uri' => $uri]);
 
-        $this->assertEquals('', (string) $result);
+        $this->assertEquals('', $result->toString());
         $this->assertSame('https', $result->scheme);
     }
 

--- a/test/Http/SegmentTest.php
+++ b/test/Http/SegmentTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace LaminasTest\Router\Http;
 
-use Laminas\Http\Request;
+use Laminas\Diactoros\Request;
+use Laminas\Diactoros\Uri;
 use Laminas\Router\Exception\InvalidArgumentException;
 use Laminas\Router\Exception\RuntimeException;
 use Laminas\Router\Http\HttpRouteMatch;
 use Laminas\Router\Http\Segment;
-use Laminas\Stdlib\Request as BaseRequest;
 use Laminas\Translator\TranslatorInterface;
 use LaminasTest\Router\FactoryTester;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -318,8 +318,8 @@ final class SegmentTest extends TestCase
         array $options = []
     ): void {
         $request = new Request();
-        $request->setUri('http://example.com' . $path);
-        $match = $route->match($request, $offset, $options);
+        $request = $request->withUri(new Uri('http://example.com' . $path));
+        $match   = $route->match($request, $offset, $options);
 
         if ($params === null) {
             $this->assertNull($match);
@@ -327,7 +327,7 @@ final class SegmentTest extends TestCase
             $this->assertInstanceOf(HttpRouteMatch::class, $match);
 
             if ($offset === null) {
-                $this->assertEquals(strlen($path), $match->getLength());
+                $this->assertEquals(strlen($request->getUri()->getPath()), $match->getLength());
             }
 
             foreach ($params as $key => $value) {
@@ -356,9 +356,9 @@ final class SegmentTest extends TestCase
         $result = $route->assemble($params, $options);
 
         if ($offset !== null) {
-            $this->assertEquals($offset, strpos($path, $result, $offset));
+            $this->assertEquals($offset, strpos($path, (string) $result, $offset));
         } else {
-            $this->assertEquals($path, $result);
+            $this->assertEquals($path, (string) $result);
         }
     }
 
@@ -373,8 +373,8 @@ final class SegmentTest extends TestCase
         array $options = []
     ): void {
         $request = new Request();
-        $request->setUri('http://example.com' . $path);
-        $match = $route->match($request, $offset, $options);
+        $request = $request->withUri(new Uri('http://example.com' . $path));
+        $match   = $route->match($request, $offset, $options);
 
         if ($params === null) {
             $this->assertNull($match);
@@ -409,7 +409,7 @@ final class SegmentTest extends TestCase
         $result = $route->assemble($params, $options);
 
         if ($offset !== null) {
-            $this->assertEquals($offset, strpos($path, $result, $offset));
+            $this->assertEquals($offset, strpos($path, (string) $result, $offset));
         } else {
             $this->assertEquals($path, $result);
         }
@@ -456,7 +456,7 @@ final class SegmentTest extends TestCase
     public function testNoMatchWithoutUriMethod(): void
     {
         $route   = new Segment('/foo');
-        $request = new BaseRequest();
+        $request = new Request();
 
         $this->assertNull($route->match($request));
     }
@@ -490,9 +490,9 @@ final class SegmentTest extends TestCase
         // this includes every character other than #, %, / and ?
         $raw     = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`-=[]\\;\',.~!@$^&*()_+{}|:"<>';
         $request = new Request();
-        $request->setUri('http://example.com/' . $raw);
-        $route = new Segment('/:foo');
-        $match = $route->match($request);
+        $request = $request->withUri(new Uri('http://example.com/' . $raw));
+        $route   = new Segment('/:foo');
+        $match   = $route->match($request);
 
         self::assertNotNull($match);
         $this->assertSame($raw, $match->getParam('foo'));
@@ -507,9 +507,9 @@ final class SegmentTest extends TestCase
         // @codingStandardsIgnoreEnd
 
         $request = new Request();
-        $request->setUri('http://example.com/' . $in);
-        $route = new Segment('/:foo');
-        $match = $route->match($request);
+        $request = $request->withUri(new Uri('http://example.com/' . $in));
+        $route   = new Segment('/:foo');
+        $match   = $route->match($request);
 
         self::assertNotNull($match);
         $this->assertSame($out, $match->getParam('foo'));
@@ -525,12 +525,12 @@ final class SegmentTest extends TestCase
         $route   = new Segment('example.com/:p1/:p2');
         $request = new Request();
 
-        $request->setUri($uri1);
+        $request = $request->withUri(new Uri($uri1));
         $route->match($request);
-        $this->assertSame($uri1, $route->assemble($params1));
+        $this->assertSame($uri1, (string) $route->assemble($params1));
 
-        $request->setUri($uri2);
+        $request = $request->withUri(new Uri($uri2));
         $route->match($request);
-        $this->assertSame($uri2, $route->assemble($params2));
+        $this->assertSame($uri2, (string) $route->assemble($params2));
     }
 }

--- a/test/Http/SegmentTest.php
+++ b/test/Http/SegmentTest.php
@@ -533,4 +533,45 @@ final class SegmentTest extends TestCase
         $route->match($request);
         $this->assertSame($uri2, $route->assemble($params2)->toString());
     }
+
+    public function testConstructWithEmptyRoute(): void
+    {
+        $route = new Segment('');
+
+        $this->assertSame('', $route->assemble([])->toString());
+    }
+
+    public function testMatchCapturesThreeParametersInOrder(): void
+    {
+        $route   = new Segment('/:one/:two/:three');
+        $request = (new Request())->withUri(new Uri('http://example.com/a/b/c'));
+        $match   = $route->match($request);
+
+        $this->assertInstanceOf(HttpRouteMatch::class, $match);
+        $this->assertSame('a', $match->getParam('one'));
+        $this->assertSame('b', $match->getParam('two'));
+        $this->assertSame('c', $match->getParam('three'));
+
+        $route->assemble(['one' => 'a', 'two' => 'b', 'three' => 'c']);
+        $this->assertSame(['one', 'two', 'three'], $route->getAssembledParams());
+    }
+
+    public function testMatchLiteralWithRegexMetacharacters(): void
+    {
+        $route   = new Segment('/foo.bar/:id');
+        $request = (new Request())->withUri(new Uri('http://example.com/foo.bar/1'));
+
+        $this->assertSame('1', $route->match($request)?->getParam('id'));
+
+        $request = (new Request())->withUri(new Uri('http://example.com/fooXbar/1'));
+        $this->assertNull($route->match($request));
+    }
+
+    public function testAssembleOmitsNestedOptionalWhenDefaults(): void
+    {
+        $route = new Segment('[:bar[/:baz]]', [], ['bar' => 'b', 'baz' => 'c']);
+
+        $this->assertSame('', $route->assemble([])->toString());
+        $this->assertSame('x', $route->assemble(['bar' => 'x'])->toString());
+    }
 }

--- a/test/Http/SegmentTest.php
+++ b/test/Http/SegmentTest.php
@@ -356,9 +356,9 @@ final class SegmentTest extends TestCase
         $result = $route->assemble($params, $options);
 
         if ($offset !== null) {
-            $this->assertEquals($offset, strpos($path, (string) $result, $offset));
+            $this->assertEquals($offset, strpos($path, $result->toString(), $offset));
         } else {
-            $this->assertEquals($path, (string) $result);
+            $this->assertEquals($path, $result->toString());
         }
     }
 
@@ -409,9 +409,9 @@ final class SegmentTest extends TestCase
         $result = $route->assemble($params, $options);
 
         if ($offset !== null) {
-            $this->assertEquals($offset, strpos($path, (string) $result, $offset));
+            $this->assertEquals($offset, strpos($path, $result->toString(), $offset));
         } else {
-            $this->assertEquals($path, $result);
+            $this->assertEquals($path, $result->toString());
         }
     }
 
@@ -466,7 +466,7 @@ final class SegmentTest extends TestCase
         $route = new Segment('/[:foo]', [], ['foo' => 'bar']);
         $path  = $route->assemble([], ['has_child' => true]);
 
-        $this->assertEquals('/bar', $path);
+        $this->assertEquals('/bar', $path->toString());
     }
 
     public function testFactory(): void
@@ -527,10 +527,10 @@ final class SegmentTest extends TestCase
 
         $request = $request->withUri(new Uri($uri1));
         $route->match($request);
-        $this->assertSame($uri1, (string) $route->assemble($params1));
+        $this->assertSame($uri1, $route->assemble($params1)->toString());
 
         $request = $request->withUri(new Uri($uri2));
         $route->match($request);
-        $this->assertSame($uri2, (string) $route->assemble($params2));
+        $this->assertSame($uri2, $route->assemble($params2)->toString());
     }
 }

--- a/test/Http/TestAsset/DummyRoute.php
+++ b/test/Http/TestAsset/DummyRoute.php
@@ -4,40 +4,45 @@ declare(strict_types=1);
 
 namespace LaminasTest\Router\Http\TestAsset;
 
+use Laminas\Router\AssembledUrl;
 use Laminas\Router\Http\HttpRouteInterface;
 use Laminas\Router\Http\HttpRouteMatch;
-use Laminas\Router\RouteMatch;
-use Laminas\Stdlib\RequestInterface;
+use Psr\Http\Message\RequestInterface;
 
 /**
  * Dummy route.
  */
-class DummyRoute implements HttpRouteInterface
+final class DummyRoute implements HttpRouteInterface
 {
     /** @inheritDoc */
     public function match(
         RequestInterface $request,
         int|null $pathOffset = null,
         array $options = []
-    ): RouteMatch {
+    ): HttpRouteMatch {
         return new HttpRouteMatch(['offset' => $pathOffset], -4);
     }
 
     /** @inheritDoc */
-    public function assemble(array $params = [], array $options = []): string
+    public function assemble(array $params = [], array $options = []): AssembledUrl
     {
-        return '';
+        return new AssembledUrl();
     }
 
     /** @inheritDoc */
     public static function factory(array $options = []): static
     {
-        return new static();
+        return new self();
     }
 
     /** @inheritDoc */
     public function getAssembledParams(): array
     {
         return [];
+    }
+
+    public function getPriority(): ?int
+    {
+        return null;
     }
 }

--- a/test/Http/TestAsset/DummyRouteWithParam.php
+++ b/test/Http/TestAsset/DummyRouteWithParam.php
@@ -4,15 +4,17 @@ declare(strict_types=1);
 
 namespace LaminasTest\Router\Http\TestAsset;
 
+use Laminas\Router\AssembledUrl;
+use Laminas\Router\Http\HttpRouteInterface;
 use Laminas\Router\Http\HttpRouteMatch;
-use Laminas\Stdlib\RequestInterface;
+use Psr\Http\Message\RequestInterface;
 
 use function array_key_exists;
 
 /**
  * Dummy route.
  */
-final class DummyRouteWithParam extends DummyRoute
+final class DummyRouteWithParam implements HttpRouteInterface
 {
     /** @inheritDoc */
     public function match(
@@ -24,14 +26,25 @@ final class DummyRouteWithParam extends DummyRoute
     }
 
     /** @inheritDoc */
-    public function assemble(array $params = [], array $options = []): string
+    public function assemble(array $params = [], array $options = []): AssembledUrl
     {
-        return array_key_exists('foo', $params) ? (string) $params['foo'] : '';
+        return new AssembledUrl(array_key_exists('foo', $params) ? (string) $params['foo'] : '');
     }
 
     /** @inheritDoc */
     public static function factory(array $options = []): static
     {
         return new self();
+    }
+
+    /** @inheritDoc */
+    public function getAssembledParams(): array
+    {
+        return [];
+    }
+
+    public function getPriority(): ?int
+    {
+        return null;
     }
 }

--- a/test/Http/TranslatorAwareTreeRouteStackTest.php
+++ b/test/Http/TranslatorAwareTreeRouteStackTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace LaminasTest\Router\Http;
 
-use ArrayObject;
-use Laminas\Http\Request;
+use Laminas\Diactoros\Request;
+use Laminas\Diactoros\Uri;
+use Laminas\Router\AssembledUrl;
 use Laminas\Router\Http\HttpRouteInterface;
 use Laminas\Router\Http\TranslatorAwareTreeRouteStack;
 use Laminas\Router\RoutePluginManager;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Translator\TranslatorInterface;
-use Laminas\Uri\Http as HttpUri;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use UnexpectedValueException;
@@ -67,9 +67,7 @@ final class TranslatorAwareTreeRouteStackTest extends TestCase
 
     public function testTranslatorAwareInterfaceImplementation(): void
     {
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TranslatorAwareTreeRouteStack(new RoutePluginManager(new ServiceManager()), $prototypes);
+        $stack = new TranslatorAwareTreeRouteStack(new RoutePluginManager(new ServiceManager()));
 
         // Defaults
         $this->assertNull($stack->getTranslator());
@@ -117,9 +115,8 @@ final class TranslatorAwareTreeRouteStackTest extends TestCase
                 $this->equalTo(['translator' => $translator, 'text_domain' => 'default'])
             );
 
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TranslatorAwareTreeRouteStack(new RoutePluginManager(new ServiceManager()), $prototypes);
+        /** @var TranslatorAwareTreeRouteStack<HttpRouteInterface> $stack */
+        $stack = new TranslatorAwareTreeRouteStack(new RoutePluginManager(new ServiceManager()));
         $stack->addRoute('test', $route);
 
         $stack->match($request, null, ['translator' => $translator]);
@@ -128,7 +125,7 @@ final class TranslatorAwareTreeRouteStackTest extends TestCase
     public function testTranslatorIsPassedThroughAssembleMethod(): void
     {
         $translator = $this->createStub(TranslatorInterface::class);
-        $uri        = new HttpUri();
+        $uri        = new Uri();
 
         $route = $this->createMock(HttpRouteInterface::class);
         $route->expects($this->once())
@@ -136,11 +133,10 @@ final class TranslatorAwareTreeRouteStackTest extends TestCase
             ->with(
                 $this->equalTo([]),
                 $this->equalTo(['translator' => $translator, 'text_domain' => 'default', 'uri' => $uri])
-            );
+            )->willReturn(new AssembledUrl());
 
-                /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TranslatorAwareTreeRouteStack(new RoutePluginManager(new ServiceManager()), $prototypes);
+        /** @var TranslatorAwareTreeRouteStack<HttpRouteInterface> $stack */
+        $stack = new TranslatorAwareTreeRouteStack(new RoutePluginManager(new ServiceManager()));
         $stack->addRoute('test', $route);
 
         $stack->assemble([], ['name' => 'test', 'translator' => $translator, 'uri' => $uri]);
@@ -148,9 +144,7 @@ final class TranslatorAwareTreeRouteStackTest extends TestCase
 
     public function testAssembleRouteWithParameterLocale(): void
     {
-                /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TranslatorAwareTreeRouteStack(new RoutePluginManager(new ServiceManager()), $prototypes);
+        $stack = new TranslatorAwareTreeRouteStack(new RoutePluginManager(new ServiceManager()));
         $stack->setTranslator($this->getTranslator(2), 'route');
         $stack->addRoute(
             'foo',
@@ -163,9 +157,7 @@ final class TranslatorAwareTreeRouteStackTest extends TestCase
 
     public function testMatchRouteWithParameterLocale(): void
     {
-                /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TranslatorAwareTreeRouteStack(new RoutePluginManager(new ServiceManager()), $prototypes);
+        $stack = new TranslatorAwareTreeRouteStack(new RoutePluginManager(new ServiceManager()));
         $stack->setTranslator($this->getTranslator(1), 'route');
         $stack->addRoute(
             'foo',
@@ -173,7 +165,7 @@ final class TranslatorAwareTreeRouteStackTest extends TestCase
         );
 
         $request = new Request();
-        $request->setUri('http://example.com/de/hauptseite');
+        $request = $request->withUri(new Uri('http://example.com/de/hauptseite'));
 
         $match = $stack->match($request);
         $this->assertNotNull($match);

--- a/test/Http/TranslatorAwareTreeRouteStackTest.php
+++ b/test/Http/TranslatorAwareTreeRouteStackTest.php
@@ -7,6 +7,7 @@ namespace LaminasTest\Router\Http;
 use Laminas\Diactoros\Request;
 use Laminas\Diactoros\Uri;
 use Laminas\Router\AssembledUrl;
+use Laminas\Router\Exception\RuntimeException;
 use Laminas\Router\Http\HttpRouteInterface;
 use Laminas\Router\Http\TranslatorAwareTreeRouteStack;
 use Laminas\Router\RoutePluginManager;
@@ -176,5 +177,46 @@ final class TranslatorAwareTreeRouteStackTest extends TestCase
         $match = $stack->match($request);
         $this->assertNotNull($match);
         $this->assertEquals('foo/index', $match->getMatchedRouteName());
+    }
+
+    public function testMatchDoesNotTranslateWhenTranslatorDisabled(): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->expects($this->never())->method('translate');
+
+        $stack = new TranslatorAwareTreeRouteStack(new RoutePluginManager(new ServiceManager()));
+        $stack->setTranslator($translator);
+        $stack->setTranslatorEnabled(false);
+        $stack->addRoute('foo', $this->fooRoute);
+
+        $request = (new Request())->withUri(new Uri('http://example.com/de/hauptseite'));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('No translator provided');
+        $stack->match($request);
+    }
+
+    public function testAssembleDoesNotTranslateWhenTranslatorDisabled(): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->expects($this->never())->method('translate');
+
+        $stack = new TranslatorAwareTreeRouteStack(new RoutePluginManager(new ServiceManager()));
+        $stack->setTranslator($translator);
+        $stack->setTranslatorEnabled(false);
+        $stack->addRoute('foo', $this->fooRoute);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('No translator provided');
+        $stack->assemble(['locale' => 'de'], ['name' => 'foo/index']);
+    }
+
+    public function testSetTranslatorEnabledDefaultsToTrue(): void
+    {
+        $stack = new TranslatorAwareTreeRouteStack(new RoutePluginManager(new ServiceManager()));
+        $stack->setTranslator($this->createStub(TranslatorInterface::class));
+        $stack->setTranslatorEnabled();
+
+        $this->assertTrue($stack->isTranslatorEnabled());
     }
 }

--- a/test/Http/TranslatorAwareTreeRouteStackTest.php
+++ b/test/Http/TranslatorAwareTreeRouteStackTest.php
@@ -151,8 +151,14 @@ final class TranslatorAwareTreeRouteStackTest extends TestCase
             $this->fooRoute
         );
 
-        $this->assertEquals('/de/hauptseite', $stack->assemble(['locale' => 'de'], ['name' => 'foo/index']));
-        $this->assertEquals('/en/homepage', $stack->assemble(['locale' => 'en'], ['name' => 'foo/index']));
+        $this->assertEquals(
+            '/de/hauptseite',
+            $stack->assemble(['locale' => 'de'], ['name' => 'foo/index'])->toString()
+        );
+        $this->assertEquals(
+            '/en/homepage',
+            $stack->assemble(['locale' => 'en'], ['name' => 'foo/index'])->toString()
+        );
     }
 
     public function testMatchRouteWithParameterLocale(): void

--- a/test/Http/TreeRouteStackTest.php
+++ b/test/Http/TreeRouteStackTest.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace LaminasTest\Router\Http;
 
-use ArrayObject;
-use Laminas\Http\PhpEnvironment\Request as PhpRequest;
-use Laminas\Http\Request;
+use Laminas\Diactoros\Request;
+use Laminas\Diactoros\Uri;
 use Laminas\Router\Exception\InvalidArgumentException;
 use Laminas\Router\Exception\RuntimeException;
 use Laminas\Router\Http\Hostname;
@@ -15,8 +14,6 @@ use Laminas\Router\Http\TreeRouteStack;
 use Laminas\Router\PriorityList;
 use Laminas\Router\RoutePluginManager;
 use Laminas\ServiceManager\ServiceManager;
-use Laminas\Stdlib\Request as BaseRequest;
-use Laminas\Uri\Http as HttpUri;
 use LaminasTest\Router\FactoryTester;
 use LaminasTest\Router\TestAsset\DummyRoute;
 use PHPUnit\Framework\TestCase;
@@ -36,9 +33,7 @@ final class TreeRouteStackTest extends TestCase
 
     public function testAddRouteRequiresHttpSpecificRoute(): void
     {
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack(new RoutePluginManager(new ServiceManager()), $prototypes);
+        $stack = new TreeRouteStack(new RoutePluginManager(new ServiceManager()));
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Only HttpRouteInterface instances or array/string specifications are allowed.');
@@ -53,9 +48,7 @@ final class TreeRouteStackTest extends TestCase
                 DummyRoute::class => DummyRoute::class,
             ],
         ]);
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack($plugins, $prototypes);
+        $stack   = new TreeRouteStack($plugins);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Given route does not implement HTTP route interface');
@@ -66,52 +59,15 @@ final class TreeRouteStackTest extends TestCase
 
     public function testNoMatchWithoutUriMethod(): void
     {
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack($this->createRoutePluginManager(), $prototypes);
-        $request    = new BaseRequest();
+        $stack   = new TreeRouteStack($this->createRoutePluginManager());
+        $request = new Request();
 
         $this->assertNull($stack->match($request));
     }
 
-    public function testSetBaseUrlFromFirstMatch(): void
+    public function testNoOffsetIsPassed(): void
     {
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack($this->createRoutePluginManager(), $prototypes);
-
-        $request = new PhpRequest();
-        $request->setBaseUrl('/foo');
-        $stack->match($request);
-        $this->assertEquals('/foo', $stack->getBaseUrl());
-
-        $request = new PhpRequest();
-        $request->setBaseUrl('/bar');
-        $stack->match($request);
-        $this->assertEquals('/foo', $stack->getBaseUrl());
-    }
-
-    public function testBaseUrlLengthIsPassedAsOffset(): void
-    {
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack($this->createRoutePluginManager(), $prototypes);
-        $stack->setBaseUrl('/foo');
-        $stack->addRoute('foo', [
-            'type' => TestAsset\DummyRoute::class,
-        ]);
-        $match = $stack->match(new Request());
-
-        self::assertNotNull($match);
-
-        $this->assertEquals(4, $match->getParam('offset'));
-    }
-
-    public function testNoOffsetIsPassedWithoutBaseUrl(): void
-    {
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack($this->createRoutePluginManager(), $prototypes);
+        $stack = new TreeRouteStack($this->createRoutePluginManager());
         $stack->addRoute('foo', [
             'type' => TestAsset\DummyRoute::class,
         ]);
@@ -124,18 +80,16 @@ final class TreeRouteStackTest extends TestCase
 
     public function testAssemble(): void
     {
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack($this->createRoutePluginManager(), $prototypes);
+        /** @var TreeRouteStack<HttpRouteInterface> $stack */
+        $stack = new TreeRouteStack($this->createRoutePluginManager());
         $stack->addRoute('foo', new TestAsset\DummyRoute());
         $this->assertEquals('', $stack->assemble([], ['name' => 'foo']));
     }
 
     public function testAssembleCanonicalUriWithoutRequestUri(): void
     {
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack($this->createRoutePluginManager(), $prototypes);
+        /** @var TreeRouteStack<HttpRouteInterface> $stack */
+        $stack = new TreeRouteStack($this->createRoutePluginManager());
         $stack->addRoute('foo', new TestAsset\DummyRoute());
 
         $this->expectException(RuntimeException::class);
@@ -145,52 +99,48 @@ final class TreeRouteStackTest extends TestCase
 
     public function testAssembleCanonicalUriWithRequestUri(): void
     {
-        $uri = new HttpUri('http://example.com:8080/');
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack(new RoutePluginManager(new ServiceManager()), $prototypes);
+        $uri = new Uri('http://example.com:8080/');
+        /** @var TreeRouteStack<HttpRouteInterface> $stack */
+        $stack = new TreeRouteStack(new RoutePluginManager(new ServiceManager()));
         $stack->setRequestUri($uri);
 
         $stack->addRoute('foo', new TestAsset\DummyRoute());
         $this->assertEquals(
             'http://example.com:8080/',
-            $stack->assemble([], ['name' => 'foo', 'force_canonical' => true])
+            (string) $stack->assemble([], ['name' => 'foo', 'force_canonical' => true])
         );
     }
 
     public function testAssembleCanonicalUriWithGivenUri(): void
     {
-        $uri = new HttpUri('http://example.com:8080/');
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack(new RoutePluginManager(new ServiceManager()), $prototypes);
+        $uri = new Uri('http://example.com:8080/');
+        /** @var TreeRouteStack<HttpRouteInterface> $stack */
+        $stack = new TreeRouteStack(new RoutePluginManager(new ServiceManager()));
 
         $stack->addRoute('foo', new TestAsset\DummyRoute());
         $this->assertEquals(
             'http://example.com:8080/',
-            $stack->assemble([], ['name' => 'foo', 'uri' => $uri, 'force_canonical' => true])
+            (string) $stack->assemble([], ['name' => 'foo', 'uri' => $uri, 'force_canonical' => true])
         );
     }
 
     public function testAssembleCanonicalUriWithHostnameRoute(): void
     {
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack(new RoutePluginManager(new ServiceManager()), $prototypes);
+        /** @var TreeRouteStack<HttpRouteInterface> $stack */
+        $stack = new TreeRouteStack(new RoutePluginManager(new ServiceManager()));
         $stack->addRoute('foo', new Hostname('example.com'));
-        $uri = new HttpUri();
-        $uri->setScheme('http');
+        $uri = new Uri();
+        $uri = $uri->withScheme('http');
 
-        $this->assertEquals('http://example.com/', $stack->assemble([], ['name' => 'foo', 'uri' => $uri]));
+        $this->assertEquals('http://example.com/', (string) $stack->assemble([], ['name' => 'foo', 'uri' => $uri]));
     }
 
     public function testAssembleCanonicalUriWithHostnameRouteWithoutScheme(): void
     {
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack(new RoutePluginManager(new ServiceManager()), $prototypes);
+        /** @var TreeRouteStack<HttpRouteInterface> $stack */
+        $stack = new TreeRouteStack(new RoutePluginManager(new ServiceManager()));
         $stack->addRoute('foo', new Hostname('example.com'));
-        $uri = new HttpUri();
+        $uri = new Uri();
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Request URI has not been set');
@@ -199,22 +149,19 @@ final class TreeRouteStackTest extends TestCase
 
     public function testAssembleCanonicalUriWithHostnameRouteAndRequestUriWithoutScheme(): void
     {
-        $uri = new HttpUri();
-        $uri->setScheme('http');
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack(new RoutePluginManager(new ServiceManager()), $prototypes);
+        $uri = new Uri();
+        $uri = $uri->withScheme('http');
+        /** @var TreeRouteStack<HttpRouteInterface> $stack */
+        $stack = new TreeRouteStack(new RoutePluginManager(new ServiceManager()));
         $stack->setRequestUri($uri);
         $stack->addRoute('foo', new Hostname('example.com'));
 
-        $this->assertEquals('http://example.com/', $stack->assemble([], ['name' => 'foo']));
+        $this->assertEquals('http://example.com/', (string) $stack->assemble([], ['name' => 'foo']));
     }
 
     public function testAssembleWithQueryParams(): void
     {
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack(new RoutePluginManager(new ServiceManager()), $prototypes);
+        $stack = new TreeRouteStack(new RoutePluginManager(new ServiceManager()));
         $stack->addRoute(
             'index',
             [
@@ -225,14 +172,15 @@ final class TreeRouteStackTest extends TestCase
             ]
         );
 
-        $this->assertEquals('/?foo=bar', $stack->assemble([], ['name' => 'index', 'query' => ['foo' => 'bar']]));
+        $this->assertEquals(
+            '/?foo=bar',
+            (string) $stack->assemble([], ['name' => 'index', 'query' => ['foo' => 'bar']])
+        );
     }
 
     public function testAssembleWithEncodedPath(): void
     {
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack(new RoutePluginManager(new ServiceManager()), $prototypes);
+        $stack = new TreeRouteStack(new RoutePluginManager(new ServiceManager()));
         $stack->addRoute(
             'index',
             [
@@ -243,14 +191,12 @@ final class TreeRouteStackTest extends TestCase
             ]
         );
 
-        $this->assertEquals('/this%2Fthat', $stack->assemble([], ['name' => 'index']));
+        $this->assertEquals('/this%2Fthat', (string) $stack->assemble([], ['name' => 'index']));
     }
 
     public function testAssembleWithEncodedPathAndQueryParams(): void
     {
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack(new RoutePluginManager(new ServiceManager()), $prototypes);
+        $stack = new TreeRouteStack(new RoutePluginManager(new ServiceManager()));
         $stack->addRoute(
             'index',
             [
@@ -263,18 +209,16 @@ final class TreeRouteStackTest extends TestCase
 
         $this->assertEquals(
             '/this%2Fthat?foo=bar',
-            $stack->assemble([], ['name' => 'index', 'query' => ['foo' => 'bar'], 'normalize_path' => false])
+            (string) $stack->assemble([], ['name' => 'index', 'query' => ['foo' => 'bar'], 'normalize_path' => false])
         );
     }
 
     public function testAssembleWithScheme(): void
     {
-        $uri = new HttpUri();
-        $uri->setScheme('http');
-        $uri->setHost('example.com');
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack(new RoutePluginManager(new ServiceManager()), $prototypes);
+        $uri   = new Uri();
+        $uri   = $uri->withScheme('http');
+        $uri   = $uri->withHost('example.com');
+        $stack = new TreeRouteStack(new RoutePluginManager(new ServiceManager()));
         $stack->setRequestUri($uri);
         $stack->addRoute(
             'secure',
@@ -298,9 +242,7 @@ final class TreeRouteStackTest extends TestCase
 
     public function testAssembleWithFragment(): void
     {
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack(new RoutePluginManager(new ServiceManager()), $prototypes);
+        $stack = new TreeRouteStack(new RoutePluginManager(new ServiceManager()));
         $stack->addRoute(
             'index',
             [
@@ -316,9 +258,7 @@ final class TreeRouteStackTest extends TestCase
 
     public function testAssembleWithoutNameOption(): void
     {
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack(new RoutePluginManager(new ServiceManager()), $prototypes);
+        $stack = new TreeRouteStack(new RoutePluginManager(new ServiceManager()));
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Missing "name" option');
@@ -327,9 +267,7 @@ final class TreeRouteStackTest extends TestCase
 
     public function testAssembleNonExistentRoute(): void
     {
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack(new RoutePluginManager(new ServiceManager()), $prototypes);
+        $stack = new TreeRouteStack(new RoutePluginManager(new ServiceManager()));
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Route with name "foo" not found');
@@ -338,9 +276,7 @@ final class TreeRouteStackTest extends TestCase
 
     public function testAssembleNonExistentChildRoute(): void
     {
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack(new RoutePluginManager(new ServiceManager()), $prototypes);
+        $stack = new TreeRouteStack(new RoutePluginManager(new ServiceManager()));
         $stack->addRoute(
             'index',
             [
@@ -356,73 +292,31 @@ final class TreeRouteStackTest extends TestCase
         $stack->assemble([], ['name' => 'index/foo']);
     }
 
-    public function testDefaultParamIsAddedToMatch(): void
-    {
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack(new RoutePluginManager(new ServiceManager()), $prototypes);
-        $stack->setBaseUrl('/foo');
-        $stack->addRoute('foo', new TestAsset\DummyRoute());
-        $stack->setDefaultParam('foo', 'bar');
-        $match = $stack->match(new Request());
-
-        self::assertNotNull($match);
-        $this->assertEquals('bar', $match->getParam('foo'));
-    }
-
-    public function testDefaultParamDoesNotOverrideParam(): void
-    {
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack(new RoutePluginManager(new ServiceManager()), $prototypes);
-        $stack->setBaseUrl('/foo');
-        $stack->addRoute('foo', new TestAsset\DummyRouteWithParam());
-        $stack->setDefaultParam('foo', 'baz');
-
-        $match = $stack->match(new Request());
-
-        self::assertNotNull($match);
-        $this->assertEquals('bar', $match->getParam('foo'));
-    }
-
     public function testDefaultParamIsUsedForAssembling(): void
     {
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack(new RoutePluginManager(new ServiceManager()), $prototypes);
+        /** @var TreeRouteStack<HttpRouteInterface> $stack */
+        $stack = new TreeRouteStack(new RoutePluginManager(new ServiceManager()));
         $stack->addRoute('foo', new TestAsset\DummyRouteWithParam());
         $stack->setDefaultParam('foo', 'bar');
 
-        $this->assertEquals('bar', $stack->assemble([], ['name' => 'foo']));
+        $this->assertEquals('bar', (string) $stack->assemble([], ['name' => 'foo']));
     }
 
     public function testDefaultParamDoesNotOverrideParamForAssembling(): void
     {
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack(new RoutePluginManager(new ServiceManager()), $prototypes);
+        /** @var TreeRouteStack<HttpRouteInterface> $stack */
+        $stack = new TreeRouteStack(new RoutePluginManager(new ServiceManager()));
         $stack->addRoute('foo', new TestAsset\DummyRouteWithParam());
         $stack->setDefaultParam('foo', 'baz');
 
-        $this->assertEquals('bar', $stack->assemble(['foo' => 'bar'], ['name' => 'foo']));
-    }
-
-    public function testSetBaseUrl(): void
-    {
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack(new RoutePluginManager(new ServiceManager()), $prototypes);
-
-        $stack->setBaseUrl('/foo/');
-        $this->assertEquals('/foo', $stack->getBaseUrl());
+        $this->assertEquals('bar', (string) $stack->assemble(['foo' => 'bar'], ['name' => 'foo']));
     }
 
     public function testSetRequestUri(): void
     {
-        $uri = new HttpUri();
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack(new RoutePluginManager(new ServiceManager()), $prototypes);
+        $uri = new Uri();
+
+        $stack = new TreeRouteStack(new RoutePluginManager(new ServiceManager()));
 
         $stack->setRequestUri($uri);
         $this->assertEquals($uri, $stack->getRequestUri());
@@ -430,9 +324,7 @@ final class TreeRouteStackTest extends TestCase
 
     public function testPriorityIsPassedToPartRoute(): void
     {
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack(new RoutePluginManager(new ServiceManager()), $prototypes);
+        $stack = new TreeRouteStack(new RoutePluginManager(new ServiceManager()));
         $stack->addRoutes([
             'foo' => [
                 'type'          => 'Literal',
@@ -469,17 +361,15 @@ final class TreeRouteStackTest extends TestCase
 
         self::assertNotNull($foo);
 
-        $this->assertEquals(1000, $foo->priority);
+        $this->assertEquals(1000, $foo->getPriority());
     }
 
     public function testChainRouteAssemblingWithChildrenAndSecureScheme(): void
     {
-        /** @var ArrayObject<string, HttpRouteInterface> $prototypes */
-        $prototypes = new ArrayObject();
-        $stack      = new TreeRouteStack(new RoutePluginManager(new ServiceManager()), $prototypes);
+        $stack = new TreeRouteStack(new RoutePluginManager(new ServiceManager()));
 
-        $uri = new HttpUri();
-        $uri->setHost('localhost');
+        $uri = new Uri();
+        $uri = $uri->withHost('localhost');
 
         $stack->setRequestUri($uri);
         $stack->addRoute(
@@ -502,7 +392,8 @@ final class TreeRouteStackTest extends TestCase
                 ],
             ]
         );
-        $this->assertEquals('https://localhost/foo/baz', $stack->assemble([], ['name' => 'foo/baz']));
+
+        $this->assertEquals('https://localhost/foo/baz', (string) $stack->assemble([], ['name' => 'foo/baz']));
     }
 
     public function testFactory(): void

--- a/test/Http/TreeRouteStackTest.php
+++ b/test/Http/TreeRouteStackTest.php
@@ -36,7 +36,7 @@ final class TreeRouteStackTest extends TestCase
         $stack = new TreeRouteStack(new RoutePluginManager(new ServiceManager()));
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Only HttpRouteInterface instances or array/string specifications are allowed.');
+        $this->expectExceptionMessage('Only HttpRouteInterface instances or array specifications are allowed.');
         /** @psalm-suppress InvalidArgument we're explicitly testing runtime type validation here */
         $stack->addRoute('foo', new DummyRoute());
     }
@@ -83,7 +83,7 @@ final class TreeRouteStackTest extends TestCase
         /** @var TreeRouteStack<HttpRouteInterface> $stack */
         $stack = new TreeRouteStack($this->createRoutePluginManager());
         $stack->addRoute('foo', new TestAsset\DummyRoute());
-        $this->assertEquals('', $stack->assemble([], ['name' => 'foo']));
+        $this->assertEquals('', $stack->assemble([], ['name' => 'foo'])->toString());
     }
 
     public function testAssembleCanonicalUriWithoutRequestUri(): void
@@ -107,7 +107,7 @@ final class TreeRouteStackTest extends TestCase
         $stack->addRoute('foo', new TestAsset\DummyRoute());
         $this->assertEquals(
             'http://example.com:8080/',
-            (string) $stack->assemble([], ['name' => 'foo', 'force_canonical' => true])
+            $stack->assemble([], ['name' => 'foo', 'force_canonical' => true])->toString()
         );
     }
 
@@ -120,7 +120,7 @@ final class TreeRouteStackTest extends TestCase
         $stack->addRoute('foo', new TestAsset\DummyRoute());
         $this->assertEquals(
             'http://example.com:8080/',
-            (string) $stack->assemble([], ['name' => 'foo', 'uri' => $uri, 'force_canonical' => true])
+            $stack->assemble([], ['name' => 'foo', 'uri' => $uri, 'force_canonical' => true])->toString()
         );
     }
 
@@ -132,7 +132,10 @@ final class TreeRouteStackTest extends TestCase
         $uri = new Uri();
         $uri = $uri->withScheme('http');
 
-        $this->assertEquals('http://example.com/', (string) $stack->assemble([], ['name' => 'foo', 'uri' => $uri]));
+        $this->assertEquals(
+            'http://example.com/',
+            $stack->assemble([], ['name' => 'foo', 'uri' => $uri])->toString()
+        );
     }
 
     public function testAssembleCanonicalUriWithHostnameRouteWithoutScheme(): void
@@ -156,7 +159,7 @@ final class TreeRouteStackTest extends TestCase
         $stack->setRequestUri($uri);
         $stack->addRoute('foo', new Hostname('example.com'));
 
-        $this->assertEquals('http://example.com/', (string) $stack->assemble([], ['name' => 'foo']));
+        $this->assertEquals('http://example.com/', $stack->assemble([], ['name' => 'foo'])->toString());
     }
 
     public function testAssembleWithQueryParams(): void
@@ -174,7 +177,7 @@ final class TreeRouteStackTest extends TestCase
 
         $this->assertEquals(
             '/?foo=bar',
-            (string) $stack->assemble([], ['name' => 'index', 'query' => ['foo' => 'bar']])
+            $stack->assemble([], ['name' => 'index', 'query' => ['foo' => 'bar']])->toString()
         );
     }
 
@@ -191,7 +194,7 @@ final class TreeRouteStackTest extends TestCase
             ]
         );
 
-        $this->assertEquals('/this%2Fthat', (string) $stack->assemble([], ['name' => 'index']));
+        $this->assertEquals('/this%2Fthat', $stack->assemble([], ['name' => 'index'])->toString());
     }
 
     public function testAssembleWithEncodedPathAndQueryParams(): void
@@ -209,7 +212,10 @@ final class TreeRouteStackTest extends TestCase
 
         $this->assertEquals(
             '/this%2Fthat?foo=bar',
-            (string) $stack->assemble([], ['name' => 'index', 'query' => ['foo' => 'bar'], 'normalize_path' => false])
+            $stack->assemble(
+                [],
+                ['name' => 'index', 'query' => ['foo' => 'bar'], 'normalize_path' => false]
+            )->toString()
         );
     }
 
@@ -237,7 +243,7 @@ final class TreeRouteStackTest extends TestCase
                 ],
             ]
         );
-        $this->assertEquals('https://example.com/', $stack->assemble([], ['name' => 'secure/index']));
+        $this->assertEquals('https://example.com/', $stack->assemble([], ['name' => 'secure/index'])->toString());
     }
 
     public function testAssembleWithFragment(): void
@@ -253,7 +259,7 @@ final class TreeRouteStackTest extends TestCase
             ]
         );
 
-        $this->assertEquals('/#foobar', $stack->assemble([], ['name' => 'index', 'fragment' => 'foobar']));
+        $this->assertEquals('/#foobar', $stack->assemble([], ['name' => 'index', 'fragment' => 'foobar'])->toString());
     }
 
     public function testAssembleWithoutNameOption(): void
@@ -299,7 +305,7 @@ final class TreeRouteStackTest extends TestCase
         $stack->addRoute('foo', new TestAsset\DummyRouteWithParam());
         $stack->setDefaultParam('foo', 'bar');
 
-        $this->assertEquals('bar', (string) $stack->assemble([], ['name' => 'foo']));
+        $this->assertEquals('bar', $stack->assemble([], ['name' => 'foo'])->toString());
     }
 
     public function testDefaultParamDoesNotOverrideParamForAssembling(): void
@@ -309,7 +315,7 @@ final class TreeRouteStackTest extends TestCase
         $stack->addRoute('foo', new TestAsset\DummyRouteWithParam());
         $stack->setDefaultParam('foo', 'baz');
 
-        $this->assertEquals('bar', (string) $stack->assemble(['foo' => 'bar'], ['name' => 'foo']));
+        $this->assertEquals('bar', $stack->assemble(['foo' => 'bar'], ['name' => 'foo'])->toString());
     }
 
     public function testSetRequestUri(): void
@@ -393,7 +399,7 @@ final class TreeRouteStackTest extends TestCase
             ]
         );
 
-        $this->assertEquals('https://localhost/foo/baz', (string) $stack->assemble([], ['name' => 'foo/baz']));
+        $this->assertEquals('https://localhost/foo/baz', $stack->assemble([], ['name' => 'foo/baz'])->toString());
     }
 
     public function testFactory(): void

--- a/test/PriorityListTest.php
+++ b/test/PriorityListTest.php
@@ -12,7 +12,7 @@ use function array_keys;
 
 final class PriorityListTest extends TestCase
 {
-    /** @var PriorityList<non-empty-string|array-key, RouteInterface> */
+    /** @var PriorityList<non-empty-string, RouteInterface> */
     private PriorityList $list;
 
     public function setUp(): void

--- a/test/SimpleRouteStackTest.php
+++ b/test/SimpleRouteStackTest.php
@@ -147,7 +147,7 @@ final class SimpleRouteStackTest extends TestCase
         /** @var SimpleRouteStack<RouteInterface> $stack */
         $stack = new SimpleRouteStack(new RoutePluginManager(new ServiceManager()));
         $stack->addRoute('foo', new TestAsset\DummyRoute());
-        $this->assertEquals('', $stack->assemble([], ['name' => 'foo']));
+        $this->assertEquals('', $stack->assemble([], ['name' => 'foo'])->toString());
     }
 
     public function testAssembleWithoutNameOption(): void
@@ -201,7 +201,7 @@ final class SimpleRouteStackTest extends TestCase
         $stack->addRoute('foo', new TestAsset\DummyRouteWithParam());
         $stack->setDefaultParam('foo', 'bar');
 
-        $this->assertEquals('bar', (string) $stack->assemble([], ['name' => 'foo']));
+        $this->assertEquals('bar', $stack->assemble([], ['name' => 'foo'])->toString());
     }
 
     public function testDefaultParamDoesNotOverrideParamForAssembling(): void
@@ -211,7 +211,7 @@ final class SimpleRouteStackTest extends TestCase
         $stack->addRoute('foo', new TestAsset\DummyRouteWithParam());
         $stack->setDefaultParam('foo', 'baz');
 
-        $this->assertEquals('bar', (string) $stack->assemble(['foo' => 'bar'], ['name' => 'foo']));
+        $this->assertEquals('bar', $stack->assemble(['foo' => 'bar'], ['name' => 'foo'])->toString());
     }
 
     public function testFactory(): void

--- a/test/SimpleRouteStackTest.php
+++ b/test/SimpleRouteStackTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\Router;
 
+use Laminas\Diactoros\Request;
 use Laminas\Router\Exception\InvalidArgumentException;
 use Laminas\Router\Exception\RuntimeException;
 use Laminas\Router\Http\Chain;
@@ -20,7 +21,6 @@ use Laminas\Router\RouteMatch;
 use Laminas\Router\RoutePluginManager;
 use Laminas\Router\SimpleRouteStack;
 use Laminas\ServiceManager\ServiceManager;
-use Laminas\Stdlib\Request;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -128,8 +128,7 @@ final class SimpleRouteStackTest extends TestCase
         /** @var SimpleRouteStack<RouteInterface> $stack */
         $stack = new SimpleRouteStack($this->createRoutePluginManager());
 
-        $route           = new TestAsset\DummyRouteWithParam();
-        $route->priority = 2;
+        $route = new TestAsset\DummyRouteWithParam(2);
         $stack->addRoute('baz', $route);
 
         $stack->addRoute('foo', [
@@ -157,7 +156,7 @@ final class SimpleRouteStackTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Missing "name" option');
-        $stack->assemble();
+        $stack->assemble([], []);
     }
 
     public function testAssembleNonExistentRoute(): void
@@ -202,7 +201,7 @@ final class SimpleRouteStackTest extends TestCase
         $stack->addRoute('foo', new TestAsset\DummyRouteWithParam());
         $stack->setDefaultParam('foo', 'bar');
 
-        $this->assertEquals('bar', $stack->assemble([], ['name' => 'foo']));
+        $this->assertEquals('bar', (string) $stack->assemble([], ['name' => 'foo']));
     }
 
     public function testDefaultParamDoesNotOverrideParamForAssembling(): void
@@ -212,7 +211,7 @@ final class SimpleRouteStackTest extends TestCase
         $stack->addRoute('foo', new TestAsset\DummyRouteWithParam());
         $stack->setDefaultParam('foo', 'baz');
 
-        $this->assertEquals('bar', $stack->assemble(['foo' => 'bar'], ['name' => 'foo']));
+        $this->assertEquals('bar', (string) $stack->assemble(['foo' => 'bar'], ['name' => 'foo']));
     }
 
     public function testFactory(): void
@@ -361,6 +360,6 @@ final class SimpleRouteStackTest extends TestCase
 
         $route = $router->getRoute('name');
         self::assertNotNull($route);
-        self::assertEquals($expectedPriority, $route->priority);
+        self::assertEquals($expectedPriority, $route->getPriority());
     }
 }

--- a/test/TestAsset/DummyRoute.php
+++ b/test/TestAsset/DummyRoute.php
@@ -4,20 +4,19 @@ declare(strict_types=1);
 
 namespace LaminasTest\Router\TestAsset;
 
+use Laminas\Router\AssembledUrl;
 use Laminas\Router\RouteInterface;
 use Laminas\Router\RouteMatch;
-use Laminas\Stdlib\RequestInterface;
+use Psr\Http\Message\RequestInterface;
 
 /**
  * Dummy route.
  */
-class DummyRoute implements RouteInterface
+final readonly class DummyRoute implements RouteInterface
 {
-    /**
-     * @internal
-     * @deprecated Since 3.9.0 This property will be removed or made private in version 4.0
-     */
-    public ?int $priority = null;
+    public function __construct(private int|null $priority = null)
+    {
+    }
 
     /** @inheritDoc */
     public function match(RequestInterface $request): RouteMatch
@@ -26,14 +25,22 @@ class DummyRoute implements RouteInterface
     }
 
     /** @inheritDoc */
-    public function assemble(array $params = [], array $options = []): string
+    public function assemble(array $params = [], array $options = []): AssembledUrl
     {
-        return '';
+        return new AssembledUrl();
     }
 
     /** @inheritDoc */
     public static function factory(array $options = []): static
     {
-        return new static();
+        /** @psalm-var int|null $priority */
+        $priority = $options['priority'] ?? null;
+
+        return new static($priority);
+    }
+
+    public function getPriority(): ?int
+    {
+        return $this->priority;
     }
 }

--- a/test/TestAsset/DummyRouteWithParam.php
+++ b/test/TestAsset/DummyRouteWithParam.php
@@ -4,16 +4,22 @@ declare(strict_types=1);
 
 namespace LaminasTest\Router\TestAsset;
 
+use Laminas\Router\AssembledUrl;
+use Laminas\Router\RouteInterface;
 use Laminas\Router\RouteMatch;
-use Laminas\Stdlib\RequestInterface;
+use Psr\Http\Message\RequestInterface;
 
 use function array_key_exists;
 
 /**
  * Dummy route.
  */
-final class DummyRouteWithParam extends DummyRoute
+final readonly class DummyRouteWithParam implements RouteInterface
 {
+    public function __construct(private int|null $priority = null)
+    {
+    }
+
     /** @inheritDoc */
     public function match(RequestInterface $request): RouteMatch
     {
@@ -21,14 +27,22 @@ final class DummyRouteWithParam extends DummyRoute
     }
 
     /** @inheritDoc */
-    public function assemble(array $params = [], array $options = []): string
+    public function assemble(array $params = [], array $options = []): AssembledUrl
     {
-        return array_key_exists('foo', $params) ? (string) $params['foo'] : '';
+        return new AssembledUrl(array_key_exists('foo', $params) ? (string) $params['foo'] : '');
     }
 
     /** @inheritDoc */
     public static function factory(array $options = []): static
     {
-        return new self();
+        /** @psalm-var int|null $priority */
+        $priority = $options['priority'] ?? null;
+
+        return new self($priority);
+    }
+
+    public function getPriority(): ?int
+    {
+        return $this->priority;
     }
 }

--- a/test/TestAsset/Router.php
+++ b/test/TestAsset/Router.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace LaminasTest\Router\TestAsset;
 
+use Laminas\Router\AssembledUrl;
 use Laminas\Router\RouteInterface;
 use Laminas\Router\RouteStackInterface;
-use Laminas\Stdlib\RequestInterface;
+use Psr\Http\Message\RequestInterface;
 
 /**
  * @template TRoute of RouteInterface
@@ -27,9 +28,9 @@ final class Router implements RouteStackInterface
     }
 
     /** @inheritDoc */
-    public function assemble(array $params = [], array $options = []): string
+    public function assemble(array $params = [], array $options = []): AssembledUrl
     {
-        return '';
+        return new AssembledUrl();
     }
 
     /** @inheritDoc */
@@ -50,5 +51,10 @@ final class Router implements RouteStackInterface
     /** @inheritDoc */
     public function setRoutes(array $routes): void
     {
+    }
+
+    public function getPriority(): ?int
+    {
+        return null;
     }
 }


### PR DESCRIPTION
- RouteInterface::match() now accepts Psr\Http\Message\RequestInterface instead of Laminas\Stdlib\RequestInterface.
- HTTP routing no longer depends on Laminas\Uri or Laminas\Http; URI handling uses Psr\Http\Message\UriInterface.
- assemble() returns an AssembledUrl value object (Stringable) instead of a string, with support for path, query, host, scheme, fragment, port, and canonical URLs.
- TreeRouteStack uses setRequestUri(UriInterface) / getRequestUri() for canonical assembly (replacing the previous HTTP URI / base URL APIs).
- Add getPriority(): ?int on RouteInterface; route priority is passed via constructors/factories instead of mutable public $priority properties.
- Reduce psalm-baseline.xml and fix Psalm issues
- Removed TreeRouteStack prototype routes (ArrayObject + addPrototypes() / factory prototypes option). This feature was not covered by documentation or tests in this package.
- Removed getBaseUrl() / legacy stack APIs tied to Laminas\Uri.