### PR TITLE
Move assembled parameters from route state to AssembledUrl

### DIFF
--- a/src/AssembledUrl.php
+++ b/src/AssembledUrl.php
@@ -14,12 +14,14 @@ readonly final class AssembledUrl
 {
     /**
      * @param array<string, scalar> $query
+     * @param list<non-empty-string> $assembledParams
      * @param non-empty-string|null $host
      * @param non-empty-string|null $scheme
      */
     public function __construct(
         public string $path = '',
         public array $query = [],
+        public array $assembledParams = [],
         public ?string $host = null,
         public ?string $scheme = null,
         public ?string $fragment = null,
@@ -33,6 +35,7 @@ readonly final class AssembledUrl
         return new self(
             path: $this->path . $other->path,
             query: array_merge($this->query, $other->query),
+            assembledParams: [...$this->assembledParams, ...$other->assembledParams],
             host: $other->host ?? $this->host,
             scheme: $other->scheme ?? $this->scheme,
             fragment: $other->fragment ?? $this->fragment,

--- a/src/Http/Chain.php
+++ b/src/Http/Chain.php
@@ -34,13 +34,6 @@ final class Chain extends TreeRouteStack implements HttpRouteInterface
     private array|null $chainRoutes;
 
     /**
-     * List of assembled parameters.
-     *
-     * @var list<non-empty-string>
-     */
-    private array $assembledParams = [];
-
-    /**
      * Create a new part route.
      *
      * @param array<array-key, array|TRoute> $routes
@@ -135,8 +128,6 @@ final class Chain extends TreeRouteStack implements HttpRouteInterface
             $this->chainRoutes = null;
         }
 
-        $this->assembledParams = [];
-
         $routes       = [...$this->routes];
         $lastRouteKey = array_key_last($routes);
 
@@ -150,21 +141,9 @@ final class Chain extends TreeRouteStack implements HttpRouteInterface
             $assembledUrl = $route->assemble($params, $chainOptions);
             $finalResult  = $finalResult->merge($assembledUrl);
 
-            $params = array_diff_key($params, array_flip($route->getAssembledParams()));
-
-            $this->assembledParams = [
-                ...$this->assembledParams,
-                ...$route->getAssembledParams(),
-            ];
+            $params = array_diff_key($params, array_flip($assembledUrl->assembledParams));
         }
 
         return $finalResult;
-    }
-
-    /** @inheritDoc */
-    #[Override]
-    public function getAssembledParams(): array
-    {
-        return $this->assembledParams;
     }
 }

--- a/src/Http/Hostname.php
+++ b/src/Http/Hostname.php
@@ -7,6 +7,8 @@ namespace Laminas\Router\Http;
 use Laminas\Router\AssembledUrl;
 use Laminas\Router\Exception;
 use Laminas\Router\Http\HttpRouteMatch;
+use Laminas\Router\Http\RouteBuild\RouteAssemblyBuildResult;
+use Laminas\Router\Http\RouteBuild\RouteRegexBuildResult;
 use Laminas\Router\Http\RouteDefinition\RouteDefinition;
 use Laminas\Router\Http\RouteDefinition\RouteDefinitionLiteral;
 use Laminas\Router\Http\RouteDefinition\RouteDefinitionOption;
@@ -28,28 +30,13 @@ use function strlen;
  * Note: the following type is recursive, but Psalm doesn't understand array shape recursion (yet). For now, we only
  *       represented recursion of the 'optional' part type to 1 level, to ease analysis.
  */
-final class Hostname implements HttpRouteInterface
+final readonly class Hostname implements HttpRouteInterface
 {
     /**
      * Parts of the route.
      */
-    private readonly RouteDefinition $parts;
-    /**
-     * Regex used for matching the route.
-     */
-    private readonly string $regex;
-    /**
-     * Map from regex groups to parameter names.
-     *
-     * @var array<string, string>
-     */
-    private array $paramMap = [];
-    /**
-     * List of assembled parameters.
-     *
-     * @var list<non-empty-string>
-     */
-    private array $assembledParams = [];
+    private RouteDefinition $parts;
+    private RouteRegexBuildResult $routeRegexBuildResult;
 
     /**
      * Create a new hostname route.
@@ -60,11 +47,11 @@ final class Hostname implements HttpRouteInterface
     public function __construct(
         string $route,
         array $constraints = [],
-        private readonly array $defaults = [],
-        private readonly int|null $priority = null,
+        private array $defaults = [],
+        private int|null $priority = null,
     ) {
-        $this->parts = $this->parseRouteDefinition($route);
-        $this->regex = $this->buildRegex($this->parts->getParts(), $constraints);
+        $this->parts                 = $this->parseRouteDefinition($route);
+        $this->routeRegexBuildResult = $this->buildRegex($this->parts->getParts(), $constraints);
     }
 
     /**
@@ -150,9 +137,10 @@ final class Hostname implements HttpRouteInterface
      * @param array<string, string> $constraints
      * @throws Exception\RuntimeException
      */
-    private function buildRegex(array $parts, array $constraints, int &$groupIndex = 1): string
+    private function buildRegex(array $parts, array $constraints, int $groupIndex = 1): RouteRegexBuildResult
     {
-        $regex = '';
+        $regex    = '';
+        $paramMap = [];
 
         foreach ($parts as $part) {
             if ($part instanceof RouteDefinitionLiteral) {
@@ -170,15 +158,19 @@ final class Hostname implements HttpRouteInterface
                     $regex .= '(' . $groupName . '[^' . $part->delimiter . ']+)';
                 }
 
-                $this->paramMap['param' . $groupIndex++] = $part->name;
+                $paramMap['param' . $groupIndex] = $part->name;
+                $groupIndex++;
                 continue;
             }
             if ($part instanceof RouteDefinitionOption) {
-                $regex .= '(?:' . $this->buildRegex($part->part, $constraints, $groupIndex) . ')?';
+                $child      = $this->buildRegex($part->part, $constraints, $groupIndex);
+                $regex     .= '(?:' . $child->regex . ')?';
+                $paramMap   = [...$paramMap, ...$child->paramMap];
+                $groupIndex = $child->nextGroupIndex;
             }
         }
 
-        return $regex;
+        return new RouteRegexBuildResult($regex, $paramMap, nextGroupIndex: $groupIndex);
     }
 
     /**
@@ -188,13 +180,13 @@ final class Hostname implements HttpRouteInterface
      * @param array<string, string|null|int|float> $mergedParams
      * @throws Exception\RuntimeException
      * @throws Exception\InvalidArgumentException
-     * @return non-empty-string|null
      */
-    private function buildHost(array $parts, array $mergedParams, bool $isOptional): string|null
+    private function buildHost(array $parts, array $mergedParams, bool $isOptional): RouteAssemblyBuildResult
     {
-        $host      = '';
-        $skip      = true;
-        $skippable = false;
+        $host            = '';
+        $skip            = true;
+        $skippable       = false;
+        $assembledParams = [];
 
         foreach ($parts as $part) {
             if ($part instanceof RouteDefinitionLiteral) {
@@ -210,7 +202,7 @@ final class Hostname implements HttpRouteInterface
                         throw new Exception\InvalidArgumentException(sprintf('Missing parameter "%s"', $part->name));
                     }
 
-                    return null;
+                    return new RouteAssemblyBuildResult(null, []);
                 } elseif (
                     ! $isOptional
                     || ! isset($this->defaults[$part->name])
@@ -221,26 +213,27 @@ final class Hostname implements HttpRouteInterface
 
                 $host .= (string) $mergedParams[$part->name];
 
-                $this->assembledParams[] = $part->name;
+                $assembledParams[] = $part->name;
                 continue;
             }
 
             if ($part instanceof RouteDefinitionOption) {
-                $skippable    = true;
-                $optionalPart = $this->buildHost($part->part, $mergedParams, true);
+                $skippable = true;
+                $child     = $this->buildHost($part->part, $mergedParams, true);
 
-                if ($optionalPart !== null) {
-                    $host .= $optionalPart;
-                    $skip  = false;
+                if ($child->segment !== null) {
+                    $host           .= $child->segment;
+                    $assembledParams = [...$assembledParams, ...$child->assembledParams];
+                    $skip            = false;
                 }
             }
         }
 
         if ($isOptional && $skippable && $skip) {
-            return null;
+            return new RouteAssemblyBuildResult(null, []);
         }
 
-        return $host === '' ? null : $host;
+        return new RouteAssemblyBuildResult($host === '' ? null : $host, $assembledParams);
     }
 
     /** @inheritDoc */
@@ -248,7 +241,7 @@ final class Hostname implements HttpRouteInterface
     public function match(RequestInterface $request, int|null $pathOffset = null, array $options = []): ?HttpRouteMatch
     {
         $host   = $request->getUri()->getHost();
-        $result = preg_match('(^' . $this->regex . '$)', $host, $matches);
+        $result = preg_match('(^' . $this->routeRegexBuildResult->regex . '$)', $host, $matches);
 
         if (! $result) {
             return null;
@@ -256,7 +249,7 @@ final class Hostname implements HttpRouteInterface
 
         $params = [];
 
-        foreach ($this->paramMap as $index => $name) {
+        foreach ($this->routeRegexBuildResult->paramMap as $index => $name) {
             if (isset($matches[$index]) && $matches[$index] !== '') {
                 $params[$name] = $matches[$index];
             }
@@ -269,24 +262,16 @@ final class Hostname implements HttpRouteInterface
     #[Override]
     public function assemble(array $params = [], array $options = []): AssembledUrl
     {
-        $this->assembledParams = [];
-
-        $host = $this->buildHost(
+        $result = $this->buildHost(
             $this->parts->getParts(),
             array_merge($this->defaults, $params),
-            false
+            false,
         );
 
         return new AssembledUrl(
-            host: $host,
+            assembledParams: $result->assembledParams,
+            host: $result->segment,
         );
-    }
-
-    /** @inheritDoc */
-    #[Override]
-    public function getAssembledParams(): array
-    {
-        return $this->assembledParams;
     }
 
     #[Override]

--- a/src/Http/HttpRouteInterface.php
+++ b/src/Http/HttpRouteInterface.php
@@ -13,12 +13,5 @@ use Psr\Http\Message\RequestInterface;
  */
 interface HttpRouteInterface extends RouteInterface
 {
-    /**
-     * Get a list of parameters used while assembling.
-     *
-     * @return list<non-empty-string>
-     */
-    public function getAssembledParams(): array;
-
     public function match(RequestInterface $request, int|null $pathOffset = null, array $options = []): RouteMatch|null;
 }

--- a/src/Http/Literal.php
+++ b/src/Http/Literal.php
@@ -96,13 +96,6 @@ final readonly class Literal implements HttpRouteInterface
         return new AssembledUrl(path:$this->route);
     }
 
-    /** @inheritDoc */
-    #[Override]
-    public function getAssembledParams(): array
-    {
-        return [];
-    }
-
     #[Override]
     public function getPriority(): ?int
     {

--- a/src/Http/Method.php
+++ b/src/Http/Method.php
@@ -84,13 +84,6 @@ final readonly class Method implements HttpRouteInterface
         return new AssembledUrl();
     }
 
-    /** @inheritDoc */
-    #[Override]
-    public function getAssembledParams(): array
-    {
-        return [];
-    }
-
     #[Override]
     public function getPriority(): ?int
     {

--- a/src/Http/Part.php
+++ b/src/Http/Part.php
@@ -172,7 +172,7 @@ final class Part extends TreeRouteStack implements HttpRouteInterface
         }
 
         $uri    = $this->route->assemble($params, $options);
-        $params = array_diff_key($params, array_flip($this->route->getAssembledParams()));
+        $params = array_diff_key($params, array_flip($uri->assembledParams));
 
         if (! isset($options['name'])) {
             if (! $this->mayTerminate) {
@@ -186,14 +186,5 @@ final class Part extends TreeRouteStack implements HttpRouteInterface
         $options['only_return_path'] = true;
 
         return $uri->merge(parent::assemble($params, $options));
-    }
-
-    /** @inheritDoc */
-    #[Override]
-    public function getAssembledParams(): array
-    {
-        // Part routes may not occur as base route of other part routes, so we
-        // don't have to return anything here.
-        return [];
     }
 }

--- a/src/Http/Placeholder.php
+++ b/src/Http/Placeholder.php
@@ -57,13 +57,6 @@ final readonly class Placeholder implements HttpRouteInterface
         return new AssembledUrl();
     }
 
-    /** @inheritDoc */
-    #[Override]
-    public function getAssembledParams(): array
-    {
-        return [];
-    }
-
     #[Override]
     public function getPriority(): ?int
     {

--- a/src/Http/Regex.php
+++ b/src/Http/Regex.php
@@ -25,15 +25,8 @@ use function strlen;
 /**
  * Regex route.
  */
-final class Regex implements HttpRouteInterface
+final readonly class Regex implements HttpRouteInterface
 {
-    /**
-     * List of assembled parameters.
-     *
-     * @var list<non-empty-string>
-     */
-    private array $assembledParams = [];
-
     /**
      * Create a new regex route.
      *
@@ -45,20 +38,20 @@ final class Regex implements HttpRouteInterface
         /**
          * Regex to match.
          */
-        private readonly string $regex,
+        private string $regex,
         /**
          * Specification for URL assembly.
          *
          * Parameters accepting substitutions should be denoted as "%key%"
          */
-        private readonly string $spec,
+        private string $spec,
         /**
          * Default values.
          *
          * @var array<non-empty-string, string|int>
          */
-        private readonly array $defaults = [],
-        private readonly int|null $priority = null
+        private array $defaults = [],
+        private int|null $priority = null,
     ) {
     }
 
@@ -121,9 +114,9 @@ final class Regex implements HttpRouteInterface
     #[Override]
     public function assemble(array $params = [], array $options = []): AssembledUrl
     {
-        $url                   = $this->spec;
-        $mergedParams          = array_merge($this->defaults, $params);
-        $this->assembledParams = [];
+        $url             = $this->spec;
+        $mergedParams    = array_merge($this->defaults, $params);
+        $assembledParams = [];
 
         foreach ($mergedParams as $key => $value) {
             $spec = '%' . $key . '%';
@@ -131,18 +124,11 @@ final class Regex implements HttpRouteInterface
             if (str_contains($url, $spec)) {
                 $url = str_replace($spec, rawurlencode((string) $value), $url);
 
-                $this->assembledParams[] = $key;
+                $assembledParams[] = $key;
             }
         }
 
-        return new AssembledUrl(path:$url);
-    }
-
-    /** @inheritDoc */
-    #[Override]
-    public function getAssembledParams(): array
-    {
-        return $this->assembledParams;
+        return new AssembledUrl(path: $url, assembledParams: $assembledParams);
     }
 
     #[Override]

--- a/src/Http/RouteBuild/RouteAssemblyBuildResult.php
+++ b/src/Http/RouteBuild/RouteAssemblyBuildResult.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Router\Http\RouteBuild;
+
+/**
+ * @internal
+ *
+ * @psalm-internal \Laminas\Router
+ * @psalm-internal \LaminasTest\Router
+ */
+final readonly class RouteAssemblyBuildResult
+{
+    /**
+     * @param non-empty-string|null $segment
+     * @param list<non-empty-string> $assembledParams
+     */
+    public function __construct(
+        public string|null $segment,
+        public array $assembledParams = []
+    ) {
+    }
+}

--- a/src/Http/RouteBuild/RouteRegexBuildResult.php
+++ b/src/Http/RouteBuild/RouteRegexBuildResult.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Router\Http\RouteBuild;
+
+/**
+ * @internal
+ *
+ * @psalm-internal \Laminas\Router
+ * @psalm-internal \LaminasTest\Router
+ */
+final readonly class RouteRegexBuildResult
+{
+    /**
+     * @param array<string, string> $paramMap
+     * @param list<string> $translationKeys
+     */
+    public function __construct(
+        public string $regex,
+        public array $paramMap,
+        public array $translationKeys = [],
+        public int $nextGroupIndex = 1,
+    ) {
+    }
+}

--- a/src/Http/RouteBuild/SegmentPathEncoder.php
+++ b/src/Http/RouteBuild/SegmentPathEncoder.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Router\Http\RouteBuild;
+
+use function rawurldecode;
+use function rawurlencode;
+use function strtr;
+
+/**
+ * @internal
+ *
+ * @psalm-internal \Laminas\Router
+ * @psalm-internal \LaminasTest\Router
+ */
+final class SegmentPathEncoder
+{
+    /**
+     * Cache for the encode output.
+     *
+     * @var array<string, string>
+     */
+    private static array $cacheEncode = [];
+
+    /**
+     * Map of allowed special chars in path segments.
+     *
+     * http://tools.ietf.org/html/rfc3986#appendix-A
+     * segement      = *pchar
+     * pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
+     * unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
+     * sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
+     *               / "*" / "+" / "," / ";" / "="
+     *
+     * @var array<string, string>
+     */
+    private static array $urlencodeCorrectionMap = [
+        '%21' => "!", // sub-delims
+        '%24' => "$", // sub-delims
+        '%26' => "&", // sub-delims
+        '%27' => "'", // sub-delims
+        '%28' => "(", // sub-delims
+        '%29' => ")", // sub-delims
+        '%2A' => "*", // sub-delims
+        '%2B' => "+", // sub-delims
+        '%2C' => ",", // sub-delims
+//      '%2D' => "-", // unreserved - not touched by rawurlencode
+//      '%2E' => ".", // unreserved - not touched by rawurlencode
+        '%3A' => ":", // pchar
+        '%3B' => ";", // sub-delims
+        '%3D' => "=", // sub-delims
+        '%40' => "@", // pchar
+//      '%5F' => "_", // unreserved - not touched by rawurlencode
+//      '%7E' => "~", // unreserved - not touched by rawurlencode
+    ];
+
+    public static function encode(string $value): string
+    {
+        if (! isset(self::$cacheEncode[$value])) {
+            self::$cacheEncode[$value] = rawurlencode($value);
+            self::$cacheEncode[$value] = strtr(self::$cacheEncode[$value], self::$urlencodeCorrectionMap);
+        }
+
+        return self::$cacheEncode[$value];
+    }
+
+    public static function decode(string $value): string
+    {
+        return rawurldecode($value);
+    }
+}

--- a/src/Http/Scheme.php
+++ b/src/Http/Scheme.php
@@ -72,13 +72,6 @@ final readonly class Scheme implements HttpRouteInterface
         return new AssembledUrl(scheme:$this->scheme);
     }
 
-    /** @inheritDoc */
-    #[Override]
-    public function getAssembledParams(): array
-    {
-        return [];
-    }
-
     #[Override]
     public function getPriority(): ?int
     {

--- a/src/Http/Segment.php
+++ b/src/Http/Segment.php
@@ -6,6 +6,9 @@ namespace Laminas\Router\Http;
 
 use Laminas\Router\AssembledUrl;
 use Laminas\Router\Exception;
+use Laminas\Router\Http\RouteBuild\RouteAssemblyBuildResult;
+use Laminas\Router\Http\RouteBuild\RouteRegexBuildResult;
+use Laminas\Router\Http\RouteBuild\SegmentPathEncoder;
 use Laminas\Router\Http\RouteDefinition\RouteDefinition;
 use Laminas\Router\Http\RouteDefinition\RouteDefinitionLiteral;
 use Laminas\Router\Http\RouteDefinition\RouteDefinitionOption;
@@ -21,87 +24,20 @@ use function array_merge;
 use function is_string;
 use function preg_match;
 use function preg_quote;
-use function rawurldecode;
-use function rawurlencode;
 use function sprintf;
 use function str_replace;
 use function strlen;
-use function strtr;
 
 /**
  * Segment route.
  */
-final class Segment implements HttpRouteInterface
+final readonly class Segment implements HttpRouteInterface
 {
-    /**
-     * Cache for the encode output.
-     *
-     * @var array<string, string>
-     */
-    private static array $cacheEncode = [];
-
-    /**
-     * Map of allowed special chars in path segments.
-     *
-     * http://tools.ietf.org/html/rfc3986#appendix-A
-     * segement      = *pchar
-     * pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
-     * unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
-     * sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
-     *               / "*" / "+" / "," / ";" / "="
-     *
-     * @var array<string, string>
-     */
-    private static array $urlencodeCorrectionMap = [
-        '%21' => "!", // sub-delims
-        '%24' => "$", // sub-delims
-        '%26' => "&", // sub-delims
-        '%27' => "'", // sub-delims
-        '%28' => "(", // sub-delims
-        '%29' => ")", // sub-delims
-        '%2A' => "*", // sub-delims
-        '%2B' => "+", // sub-delims
-        '%2C' => ",", // sub-delims
-//      '%2D' => "-", // unreserved - not touched by rawurlencode
-//      '%2E' => ".", // unreserved - not touched by rawurlencode
-        '%3A' => ":", // pchar
-        '%3B' => ";", // sub-delims
-        '%3D' => "=", // sub-delims
-        '%40' => "@", // pchar
-//      '%5F' => "_", // unreserved - not touched by rawurlencode
-//      '%7E' => "~", // unreserved - not touched by rawurlencode
-    ];
-
     /**
      * Parts of the route.
      */
-    private readonly RouteDefinition $parts;
-
-    /**
-     * Regex used for matching the route.
-     */
-    private readonly string $regex;
-
-    /**
-     * Map from regex groups to parameter names.
-     *
-     * @var array<string, string>
-     */
-    private array $paramMap = [];
-
-    /**
-     * List of assembled parameters.
-     *
-     * @var list<non-empty-string>
-     */
-    private array $assembledParams = [];
-
-    /**
-     * Translation keys used in the regex.
-     *
-     * @var list<string>
-     */
-    private array $translationKeys = [];
+    private RouteDefinition $parts;
+    private RouteRegexBuildResult $routeRegexBuildResult;
 
     /**
      * Create a new regex route.
@@ -113,10 +49,10 @@ final class Segment implements HttpRouteInterface
         string $route,
         array $constraints = [],
         private array $defaults = [],
-        private readonly int|null $priority = null,
+        private int|null $priority = null,
     ) {
-        $this->parts = $this->parseRouteDefinition($route);
-        $this->regex = $this->buildRegex($this->parts->getParts(), $constraints);
+        $this->parts                 = $this->parseRouteDefinition($route);
+        $this->routeRegexBuildResult = $this->buildRegex($this->parts->getParts(), $constraints);
     }
 
     /**
@@ -207,9 +143,11 @@ final class Segment implements HttpRouteInterface
      * @param list<RouteDefinitionPartInterface> $parts
      * @param array<string, string> $constraints
      */
-    private function buildRegex(array $parts, array $constraints, int &$groupIndex = 1): string
+    private function buildRegex(array $parts, array $constraints, int $groupIndex = 1): RouteRegexBuildResult
     {
-        $regex = '';
+        $regex           = '';
+        $paramMap        = [];
+        $translationKeys = [];
 
         foreach ($parts as $part) {
             if ($part instanceof RouteDefinitionLiteral) {
@@ -227,20 +165,25 @@ final class Segment implements HttpRouteInterface
                     $regex .= '(' . $groupName . '[^' . $part->delimiter . ']+)';
                 }
 
-                $this->paramMap['param' . $groupIndex++] = $part->name;
+                $paramMap['param' . $groupIndex] = $part->name;
+                $groupIndex++;
                 continue;
             }
             if ($part instanceof RouteDefinitionOption) {
-                $regex .= '(?:' . $this->buildRegex($part->part, $constraints, $groupIndex) . ')?';
+                $child           = $this->buildRegex($part->part, $constraints, $groupIndex);
+                $regex          .= '(?:' . $child->regex . ')?';
+                $paramMap        = [...$paramMap, ...$child->paramMap];
+                $translationKeys = [...$translationKeys, ...$child->translationKeys];
+                $groupIndex      = $child->nextGroupIndex;
                 continue;
             }
             if ($part instanceof RouteDefinitionTranslatedLiteral) {
-                $regex                  .= '#' . $part->literal . '#';
-                $this->translationKeys[] = $part->literal;
+                $regex            .= '#' . $part->literal . '#';
+                $translationKeys[] = $part->literal;
             }
         }
 
-        return $regex;
+        return new RouteRegexBuildResult($regex, $paramMap, $translationKeys, $groupIndex);
     }
 
     /**
@@ -256,13 +199,13 @@ final class Segment implements HttpRouteInterface
         array $mergedParams,
         bool $isOptional,
         bool $hasChild,
-        array $options
-    ): string {
+        array $options,
+    ): RouteAssemblyBuildResult {
         $translator = null;
         $textDomain = null;
         $locale     = null;
 
-        if ($this->translationKeys) {
+        if ($this->routeRegexBuildResult->translationKeys) {
             /** @var mixed $translator */
             $translator = $options['translator'] ?? null;
             /** @psalm-var string $textDomain */
@@ -275,9 +218,10 @@ final class Segment implements HttpRouteInterface
             }
         }
 
-        $path      = '';
-        $skip      = true;
-        $skippable = false;
+        $path            = '';
+        $skip            = true;
+        $skippable       = false;
+        $assembledParams = [];
 
         foreach ($parts as $part) {
             if ($part instanceof RouteDefinitionLiteral) {
@@ -292,7 +236,7 @@ final class Segment implements HttpRouteInterface
                         throw new Exception\InvalidArgumentException(sprintf('Missing parameter "%s"', $part->name));
                     }
 
-                    return '';
+                    return new RouteAssemblyBuildResult(null);
                 } elseif (
                     ! $isOptional
                     || $hasChild
@@ -302,18 +246,25 @@ final class Segment implements HttpRouteInterface
                     $skip = false;
                 }
 
-                $path .= $this->encode((string) $mergedParams[$part->name]);
+                $path .= SegmentPathEncoder::encode((string) $mergedParams[$part->name]);
 
-                $this->assembledParams[] = $part->name;
+                $assembledParams[] = $part->name;
                 continue;
             }
             if ($part instanceof RouteDefinitionOption) {
-                $skippable    = true;
-                $optionalPart = $this->buildPath($part->part, $mergedParams, true, $hasChild, $options);
+                $skippable = true;
+                $child     = $this->buildPath(
+                    $part->part,
+                    $mergedParams,
+                    true,
+                    $hasChild,
+                    $options,
+                );
 
-                if ($optionalPart !== '') {
-                    $path .= $optionalPart;
-                    $skip  = false;
+                if ($child->segment !== null) {
+                    $path           .= $child->segment;
+                    $assembledParams = [...$assembledParams, ...$child->assembledParams];
+                    $skip            = false;
                 }
                 continue;
             }
@@ -326,10 +277,10 @@ final class Segment implements HttpRouteInterface
         }
 
         if ($isOptional && $skippable && $skip) {
-            return '';
+            return new RouteAssemblyBuildResult(null);
         }
 
-        return $path;
+        return new RouteAssemblyBuildResult($path === '' ? null : $path, $assembledParams);
     }
 
     /**
@@ -340,9 +291,9 @@ final class Segment implements HttpRouteInterface
     public function match(RequestInterface $request, int|null $pathOffset = null, array $options = []): ?HttpRouteMatch
     {
         $path  = $request->getUri()->getPath();
-        $regex = $this->regex;
+        $regex = $this->routeRegexBuildResult->regex;
 
-        if ($this->translationKeys) {
+        if ($this->routeRegexBuildResult->translationKeys) {
             $translator = $options['translator'] ?? null;
             /** @psalm-var string $textDomain */
             $textDomain = $options['text_domain'] ?? 'default';
@@ -353,7 +304,7 @@ final class Segment implements HttpRouteInterface
                 throw new Exception\RuntimeException('No translator provided');
             }
 
-            foreach ($this->translationKeys as $key) {
+            foreach ($this->routeRegexBuildResult->translationKeys as $key) {
                 $regex = str_replace('#' . $key . '#', $translator->translate($key, $textDomain, $locale), $regex);
             }
         }
@@ -371,9 +322,9 @@ final class Segment implements HttpRouteInterface
         $matchedLength = strlen($matches[0]);
         $params        = [];
 
-        foreach ($this->paramMap as $index => $name) {
+        foreach ($this->routeRegexBuildResult->paramMap as $index => $name) {
             if (isset($matches[$index]) && $matches[$index] !== '') {
-                $params[$name] = $this->decode($matches[$index]);
+                $params[$name] = SegmentPathEncoder::decode($matches[$index]);
             }
         }
 
@@ -384,47 +335,23 @@ final class Segment implements HttpRouteInterface
     #[Override]
     public function assemble(array $params = [], array $options = []): AssembledUrl
     {
-        $this->assembledParams = [];
-
-        return new AssembledUrl(path :$this->buildPath(
+        $result = $this->buildPath(
             $this->parts->getParts(),
             array_merge($this->defaults, $params),
             false,
             array_key_exists('has_child', $options) && $options['has_child'] === true,
-            $options
-        ));
-    }
+            $options,
+        );
 
-    /** @inheritDoc */
-    #[Override]
-    public function getAssembledParams(): array
-    {
-        return $this->assembledParams;
+        return new AssembledUrl(
+            path: $result->segment ?? '',
+            assembledParams: $result->assembledParams,
+        );
     }
 
     #[Override]
     public function getPriority(): ?int
     {
         return $this->priority;
-    }
-
-    /**
-     * Encode a path segment.
-     */
-    private function encode(string $value): string
-    {
-        if (! isset(static::$cacheEncode[$value])) {
-            static::$cacheEncode[$value] = rawurlencode($value);
-            static::$cacheEncode[$value] = strtr(static::$cacheEncode[$value], static::$urlencodeCorrectionMap);
-        }
-        return static::$cacheEncode[$value];
-    }
-
-    /**
-     * Decode a path segment.
-     */
-    private function decode(string $value): string
-    {
-        return rawurldecode($value);
     }
 }

--- a/src/Http/Segment.php
+++ b/src/Http/Segment.php
@@ -21,6 +21,7 @@ use Psr\Http\Message\RequestInterface;
 
 use function array_key_exists;
 use function array_merge;
+use function count;
 use function is_string;
 use function preg_match;
 use function preg_quote;
@@ -205,7 +206,7 @@ final readonly class Segment implements HttpRouteInterface
         $textDomain = null;
         $locale     = null;
 
-        if ($this->routeRegexBuildResult->translationKeys) {
+        if (count($this->routeRegexBuildResult->translationKeys) > 0) {
             /** @var mixed $translator */
             $translator = $options['translator'] ?? null;
             /** @psalm-var string $textDomain */
@@ -293,7 +294,7 @@ final readonly class Segment implements HttpRouteInterface
         $path  = $request->getUri()->getPath();
         $regex = $this->routeRegexBuildResult->regex;
 
-        if ($this->routeRegexBuildResult->translationKeys) {
+        if (count($this->routeRegexBuildResult->translationKeys) > 0) {
             $translator = $options['translator'] ?? null;
             /** @psalm-var string $textDomain */
             $textDomain = $options['text_domain'] ?? 'default';

--- a/src/Http/TreeRouteStack.php
+++ b/src/Http/TreeRouteStack.php
@@ -282,6 +282,7 @@ class TreeRouteStack extends SimpleRouteStack
         return new AssembledUrl(
             $assembledUrl->path,
             $query,
+            $assembledUrl->assembledParams,
             $resolvedHost,
             $resolvedScheme,
             $fragment,

--- a/test/AssembledUrlTest.php
+++ b/test/AssembledUrlTest.php
@@ -10,6 +10,14 @@ use PHPUnit\Framework\TestCase;
 
 final class AssembledUrlTest extends TestCase
 {
+    public function testMergeConcatenatesAssembledParams(): void
+    {
+        $base  = new AssembledUrl(assembledParams: ['foo']);
+        $other = new AssembledUrl(assembledParams: ['bar']);
+
+        $this->assertSame(['foo', 'bar'], $base->merge($other)->assembledParams);
+    }
+
     public function testMergeCombinesPathQueryAndScalarProperties(): void
     {
         $base  = new AssembledUrl(

--- a/test/Http/ChainTest.php
+++ b/test/Http/ChainTest.php
@@ -259,9 +259,10 @@ final class ChainTest extends TestCase
     public function testGetAssembledParams(): void
     {
         $route = self::getRoute();
-        $route->assemble(['controller' => 'foo', 'bar' => 'baz']);
-
-        $this->assertSame(['controller', 'bar'], $route->getAssembledParams());
+        $this->assertSame(
+            ['controller', 'bar'],
+            $route->assemble(['controller' => 'foo', 'bar' => 'baz'])->assembledParams,
+        );
     }
 
     public function testFactory(): void

--- a/test/Http/HostnameTest.php
+++ b/test/Http/HostnameTest.php
@@ -256,9 +256,10 @@ final class HostnameTest extends TestCase
     {
         $route = new Hostname(':foo.example.com');
         $uri   = new Uri();
-        $route->assemble(['foo' => 'bar', 'baz' => 'bat'], ['uri' => $uri]);
-
-        $this->assertEquals(['foo'], $route->getAssembledParams());
+        $this->assertEquals(
+            ['foo'],
+            $route->assemble(['foo' => 'bar', 'baz' => 'bat'], ['uri' => $uri])->assembledParams,
+        );
     }
 
     public function testMatchIncludesDefaultsNotCapturedInHostname(): void
@@ -316,6 +317,16 @@ final class HostnameTest extends TestCase
         $this->assertSame('x.b.example.com', $route->assemble(['foo' => 'x'])->host);
     }
 
+    public function testAssembleNestedOptionalCollectsAssembledParamsFromBothLevels(): void
+    {
+        $route = new Hostname('[[:foo.]:bar.]example.com');
+
+        $this->assertSame(
+            ['foo', 'bar'],
+            $route->assemble(['foo' => 'baz', 'bar' => 'bat'])->assembledParams,
+        );
+    }
+
     public function testMatchCapturesThreeParametersInOrder(): void
     {
         $route   = new Hostname(':one.:two.:three.example.com');
@@ -327,8 +338,10 @@ final class HostnameTest extends TestCase
         $this->assertSame('b', $match->getParam('two'));
         $this->assertSame('c', $match->getParam('three'));
 
-        $route->assemble(['one' => 'a', 'two' => 'b', 'three' => 'c']);
-        $this->assertSame(['one', 'two', 'three'], $route->getAssembledParams());
+        $this->assertSame(
+            ['one', 'two', 'three'],
+            $route->assemble(['one' => 'a', 'two' => 'b', 'three' => 'c'])->assembledParams,
+        );
     }
 
     public function testConstructWithEmptyRoute(): void

--- a/test/Http/LiteralTest.php
+++ b/test/Http/LiteralTest.php
@@ -109,9 +109,7 @@ final class LiteralTest extends TestCase
     public function testGetAssembledParams(): void
     {
         $route = new Literal('/foo');
-        $route->assemble(['foo' => 'bar']);
-
-        $this->assertEquals([], $route->getAssembledParams());
+        $this->assertEquals([], $route->assemble(['foo' => 'bar'])->assembledParams);
     }
 
     public function testFactory(): void

--- a/test/Http/PartTest.php
+++ b/test/Http/PartTest.php
@@ -292,9 +292,10 @@ final class PartTest extends TestCase
     public function testGetAssembledParams(): void
     {
         $route = self::getRoute();
-        $route->assemble(['controller' => 'foo'], ['name' => 'baz/bat']);
-
-        $this->assertEquals([], $route->getAssembledParams());
+        $this->assertEquals(
+            ['controller'],
+            $route->assemble(['controller' => 'foo'], ['name' => 'baz/bat'])->assembledParams,
+        );
     }
 
     public function testFactory(): void

--- a/test/Http/PlaceholderTest.php
+++ b/test/Http/PlaceholderTest.php
@@ -68,7 +68,7 @@ final class PlaceholderTest extends TestCase
     public function testGetAssembledParams(): void
     {
         $route = new Placeholder([]);
-        $this->assertEquals([], $route->getAssembledParams());
+        $this->assertEquals([], $route->assemble([])->assembledParams);
     }
 
     public function testFactory(): void

--- a/test/Http/RegexTest.php
+++ b/test/Http/RegexTest.php
@@ -136,9 +136,7 @@ final class RegexTest extends TestCase
     public function testGetAssembledParams(): void
     {
         $route = new Regex('/(?<foo>.+)', '/%foo%');
-        $route->assemble(['foo' => 'bar', 'baz' => 'bat']);
-
-        $this->assertEquals(['foo'], $route->getAssembledParams());
+        $this->assertEquals(['foo'], $route->assemble(['foo' => 'bar', 'baz' => 'bat'])->assembledParams);
     }
 
     public function testAssemblingUsesDefaultsForMissingParams(): void

--- a/test/Http/SchemeTest.php
+++ b/test/Http/SchemeTest.php
@@ -56,9 +56,7 @@ final class SchemeTest extends TestCase
     public function testGetAssembledParams(): void
     {
         $route = new Scheme('https');
-        $route->assemble(['foo' => 'bar']);
-
-        $this->assertEquals([], $route->getAssembledParams());
+        $this->assertEquals([], $route->assemble(['foo' => 'bar'])->assembledParams);
     }
 
     public function testFactory(): void

--- a/test/Http/SegmentTest.php
+++ b/test/Http/SegmentTest.php
@@ -552,8 +552,10 @@ final class SegmentTest extends TestCase
         $this->assertSame('b', $match->getParam('two'));
         $this->assertSame('c', $match->getParam('three'));
 
-        $route->assemble(['one' => 'a', 'two' => 'b', 'three' => 'c']);
-        $this->assertSame(['one', 'two', 'three'], $route->getAssembledParams());
+        $this->assertSame(
+            ['one', 'two', 'three'],
+            $route->assemble(['one' => 'a', 'two' => 'b', 'three' => 'c'])->assembledParams,
+        );
     }
 
     public function testMatchLiteralWithRegexMetacharacters(): void
@@ -573,5 +575,35 @@ final class SegmentTest extends TestCase
 
         $this->assertSame('', $route->assemble([])->toString());
         $this->assertSame('x', $route->assemble(['bar' => 'x'])->toString());
+    }
+
+    public function testAssembleNestedOptionalCollectsAssembledParamsFromBothLevels(): void
+    {
+        $route = new Segment('[:bar[/:baz]]', [], ['bar' => 'b', 'baz' => 'c']);
+
+        $this->assertSame(
+            ['bar', 'baz'],
+            $route->assemble(['bar' => 'x', 'baz' => 'y'])->assembledParams,
+        );
+    }
+
+    public function testMatchNestedOptionalWithTranslatedLiteralsAtBothLevels(): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('translate')->willReturnCallback(
+            static fn (string $message): string => match ($message) {
+                'outer' => 'OUT',
+                'inner' => 'IN',
+                default => $message,
+            },
+        );
+
+        $route   = new Segment('[/{outer}[/{inner}/:bar]]');
+        $request = (new Request())->withUri(new Uri('http://example.com/OUT/IN/x'));
+
+        $match = $route->match($request, null, ['translator' => $translator]);
+
+        $this->assertInstanceOf(HttpRouteMatch::class, $match);
+        $this->assertSame('x', $match->getParam('bar'));
     }
 }

--- a/test/Http/TestAsset/DummyRoute.php
+++ b/test/Http/TestAsset/DummyRoute.php
@@ -35,12 +35,6 @@ final class DummyRoute implements HttpRouteInterface
         return new self();
     }
 
-    /** @inheritDoc */
-    public function getAssembledParams(): array
-    {
-        return [];
-    }
-
     public function getPriority(): ?int
     {
         return null;

--- a/test/Http/TestAsset/DummyRouteWithParam.php
+++ b/test/Http/TestAsset/DummyRouteWithParam.php
@@ -37,12 +37,6 @@ final class DummyRouteWithParam implements HttpRouteInterface
         return new self();
     }
 
-    /** @inheritDoc */
-    public function getAssembledParams(): array
-    {
-        return [];
-    }
-
     public function getPriority(): ?int
     {
         return null;


### PR DESCRIPTION
Move assembled parameters from route state to AssembledUrl

- Remove `getAssembledParams()` from `HttpRouteInterface`.
- Add `assembledParams` property to `AssembledUrl` and update its `merge()` method to concatenate these parameters.
- Refactor `Segment`, `Regex`, and `Hostname` routes to be `readonly`, removing internal state and returning assembled parameters via the `AssembledUrl` object.
- Introduce `RouteRegexBuildResult` and `RouteAssemblyBuildResult` DTOs to handle internal data during route and path building.
- Update `Chain` and `Part` routes to retrieve assembled parameters from the `AssembledUrl` result of the `assemble()` method.
- Update unit tests to reflect the interface changes and add new test cases for nested optional parameters in `Segment` and `Hostname` routes.