### PR TITLE
Replace `route_plugins` with an instance of `RoutePluginManager`.

### DIFF
--- a/src/Http/HttpRouterFactory.php
+++ b/src/Http/HttpRouterFactory.php
@@ -40,8 +40,12 @@ final readonly class HttpRouterFactory implements FactoryInterface
             ],
         ];
 
-        $class                   = $config['router']['router_class'];
-        $config['route_plugins'] = $config['router']['route_plugins'];
+        $class              = $config['router']['router_class'];
+        $routePluginManager = $container->get($config['router']['route_plugins']);
+
+        assert($routePluginManager instanceof RoutePluginManager);
+
+        $config['route_plugins'] = $routePluginManager;
 
         $router = $class::factory($config);
 

--- a/test/RouterFactoryTest.php
+++ b/test/RouterFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\Router;
 
+use Laminas\Router\ConfigProvider;
 use Laminas\Router\Http\HttpRouterFactory;
 use Laminas\Router\Http\TreeRouteStack;
 use Laminas\Router\RoutePluginManager;
@@ -77,5 +78,13 @@ class RouterFactoryTest extends TestCase
 
         $router = $this->factory->__invoke($services, 'router');
         $this->assertInstanceOf(TestAsset\Router::class, $router);
+    }
+
+    public function testDefaultConfig(): void
+    {
+        $services = new ServiceManager((new ConfigProvider())->getDependencyConfig());
+
+        $router = $this->factory->__invoke($services, 'router');
+        $this->assertInstanceOf(TreeRouteStack::class, $router);
     }
 }


### PR DESCRIPTION
Replace `route_plugins` with an instance of `RoutePluginManager`.

- Add type assertion for `RoutePluginManager` to enhance type safety.
- Introduce `testDefaultConfig` to validate default router configuration in factory tests.