### PR TITLE
fix #1 : Add `disable_segment_encoding` option to `Segment`

### DIFF
--- a/docs/book/v4/routing.md
+++ b/docs/book/v4/routing.md
@@ -79,6 +79,7 @@ at a time using `addRoute()`, or in bulk using `addRoutes()`.
 ```php
 // One at a time:
 $route = Literal::factory([
+    'route_plugins' => new \Laminas\Router\RoutePluginManager(new \Laminas\ServiceManager\ServiceManager()),
     'route' => '/foo',
     'defaults' => [
         'controller' => 'foo-index',
@@ -172,6 +173,7 @@ and contained exactly 2 digits following, the following route would be needed:
 
 ```php
 $route = Hostname::factory([
+    'route_plugins' => new \Laminas\Router\RoutePluginManager(new \Laminas\ServiceManager\ServiceManager()),
     'route' => ':subdomain.domain.tld',
     'constraints' => [
         'subdomain' => 'fw\d{2}',
@@ -186,6 +188,7 @@ defaults.
 
 ```php
 $route = Hostname::factory([
+    'route_plugins' => new \Laminas\Router\RoutePluginManager(new \Laminas\ServiceManager\ServiceManager()),
     'route' => ':subdomain.domain.tld',
     'constraints' => [
         'subdomain' => 'fw\d{2}',
@@ -207,6 +210,7 @@ parameters you want returned on a match.
 
 ```php
 $route = Literal::factory([
+    'route_plugins' => new \Laminas\Router\RoutePluginManager(new \Laminas\ServiceManager\ServiceManager()),
     'route' => '/foo',
     'defaults' => [
         'controller' => 'Application\Controller\IndexController',
@@ -226,6 +230,7 @@ against multiple methods by providing a comma-separated list of method tokens.
 
 ```php
 $route = Method::factory([
+    'route_plugins' => new \Laminas\Router\RoutePluginManager(new \Laminas\ServiceManager\ServiceManager()),
     'verb' => 'post,put',
     'defaults' => [
         'controller' => 'Application\Controller\IndexController',
@@ -439,6 +444,7 @@ include in the `RouteMatch` when successfully matched.
 
 ```php
 $route = Regex::factory([
+    'route_plugins' => new \Laminas\Router\RoutePluginManager(new \Laminas\ServiceManager\ServiceManager()),
     'regex' => '/blog/(?<id>[a-zA-Z0-9_-]+)(\.(?<format>(json|html|xml|rss)))?',
     'defaults' => [
         'controller' => 'Application\Controller\BlogController',
@@ -462,6 +468,7 @@ and the "defaults", parameters to return on a match.
 
 ```php
 $route = Scheme::factory([
+    'route_plugins' => new \Laminas\Router\RoutePluginManager(new \Laminas\ServiceManager\ServiceManager()),
     'scheme' => 'https',
     'defaults' => [
         'https' => true,
@@ -497,6 +504,7 @@ As a complex example:
 
 ```php
 $route = Segment::factory([
+    'route_plugins' => new \Laminas\Router\RoutePluginManager(new \Laminas\ServiceManager\ServiceManager()),
     'route' => '/:controller[/:action]',
     'constraints' => [
         'controller' => '[a-zA-Z][a-zA-Z0-9_-]+',
@@ -508,6 +516,45 @@ $route = Segment::factory([
     ],
 ]);
 ```
+
+#### Disable segment encoding
+
+By default, each segment parameter is URL-encoded when assembling a URL, and
+decoded when matching one. This means a parameter value containing a `/` will
+be percent-encoded (as `%2F`) rather than being treated as a path separator:
+
+```php
+$route = Segment::factory([
+    'route_plugins' => new \Laminas\Router\RoutePluginManager(new \Laminas\ServiceManager\ServiceManager()),
+    'route' => '/example/route/with/:token',
+]);
+
+$route->assemble(['token' => 'token/with/slashes']);
+// /example/route/with/token%2Fwith%2Fslashes
+```
+
+If you need the raw, unencoded value in the resulting URL — for instance, when
+a parameter is itself expected to contain slashes — disable encoding for that
+parameter using the `disable_segment_encoding` option. This option accepts a
+map of parameter name to boolean, and affects both `assemble()` and `match()`:
+
+```php
+$route = Segment::factory([
+    'route_plugins' => new \Laminas\Router\RoutePluginManager(new \Laminas\ServiceManager\ServiceManager()),
+    'route' => '/example/route/with/:token',
+    'disable_segment_encoding' => [
+        'token' => true,
+    ],
+]);
+
+$route->assemble(['token' => 'token/with/slashes']);
+// /example/route/with/token/with/slashes
+```
+
+> **Warning**: Disabling encoding for a parameter means its value is inserted
+> into (or read from) the URL as-is. Use this with care, as unencoded values
+> can introduce ambiguity with the surrounding route structure or with other
+> segments/delimiters in the route definition.
 
 ## HTTP Routing Examples
 

--- a/src/Http/Segment.php
+++ b/src/Http/Segment.php
@@ -45,12 +45,14 @@ final readonly class Segment implements HttpRouteInterface
      *
      * @param array<string, string> $constraints
      * @param array<string, string> $defaults
+     * @param array<non-empty-string, bool> $disableSegmentEncoding
      */
     public function __construct(
         string $route,
         array $constraints = [],
         private array $defaults = [],
         private int|null $priority = null,
+        private array $disableSegmentEncoding = []
     ) {
         $this->parts                 = $this->parseRouteDefinition($route);
         $this->routeRegexBuildResult = $this->buildRegex($this->parts->getParts(), $constraints);
@@ -70,12 +72,14 @@ final readonly class Segment implements HttpRouteInterface
         $defaults = $options['defaults'] ?? [];
         /** @psalm-var int|null $priority */
         $priority = $options['priority'] ?? null;
+        /** @psalm-var array<non-empty-string, bool> $disableSegmentEncoding */
+        $disableSegmentEncoding = $options['disable_segment_encoding'] ?? [];
 
         if (! is_string($route)) {
             throw new Exception\InvalidArgumentException('Missing "route" in options array');
         }
 
-        return new self($route, $constraints, $defaults, $priority);
+        return new self($route, $constraints, $defaults, $priority, $disableSegmentEncoding);
     }
 
     /**
@@ -247,7 +251,11 @@ final readonly class Segment implements HttpRouteInterface
                     $skip = false;
                 }
 
-                $path .= SegmentPathEncoder::encode((string) $mergedParams[$part->name]);
+                if ($this->isSegmentEncodingEnabled($part->name)) {
+                    $path .= SegmentPathEncoder::encode((string) $mergedParams[$part->name]);
+                } else {
+                    $path .= (string) $mergedParams[$part->name];
+                }
 
                 $assembledParams[] = $part->name;
                 continue;
@@ -325,7 +333,11 @@ final readonly class Segment implements HttpRouteInterface
 
         foreach ($this->routeRegexBuildResult->paramMap as $index => $name) {
             if (isset($matches[$index]) && $matches[$index] !== '') {
-                $params[$name] = SegmentPathEncoder::decode($matches[$index]);
+                if ($this->isSegmentEncodingEnabled($name)) {
+                    $params[$name] = SegmentPathEncoder::decode($matches[$index]);
+                } else {
+                    $params[$name] = $matches[$index];
+                }
             }
         }
 
@@ -354,5 +366,13 @@ final readonly class Segment implements HttpRouteInterface
     public function getPriority(): ?int
     {
         return $this->priority;
+    }
+
+    private function isSegmentEncodingEnabled(string $name): bool
+    {
+        if (! array_key_exists($name, $this->disableSegmentEncoding)) {
+            return true;
+        }
+        return $this->disableSegmentEncoding[$name] !== true;
     }
 }

--- a/test/Issue/Issue1Test.php
+++ b/test/Issue/Issue1Test.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Router\Issue;
+
+use Laminas\Diactoros\Request;
+use Laminas\Diactoros\Uri;
+use Laminas\Router\Http\Segment;
+use Laminas\Router\Http\TreeRouteStack;
+use Laminas\Router\RoutePluginManager;
+use Laminas\ServiceManager\ServiceManager;
+use PHPUnit\Framework\TestCase;
+
+final class Issue1Test extends TestCase
+{
+    private function createRouter(array $segmentOptions = []): TreeRouteStack
+    {
+        return TreeRouteStack::factory([
+            'route_plugins' => new RoutePluginManager(new ServiceManager()),
+            'routes'        => [
+                'example-route' => [
+                    'type'    => Segment::class,
+                    'options' => [
+                        'route' => '/example/route/with/:token',
+                        ...$segmentOptions,
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testAssembleEncodesSegmentByDefault(): void
+    {
+        $router = $this->createRouter();
+
+        $this->assertSame(
+            '/example/route/with/token%2Fwith%2Fslashes',
+            $router->assemble(['token' => 'token/with/slashes'], ['name' => 'example-route'])->toString()
+        );
+    }
+
+    public function testMatchDecodesSegmentByDefault(): void
+    {
+        $router  = $this->createRouter();
+        $request = (new Request())->withUri(new Uri('http://example.com/example/route/with/token%2Fwith%2Fslashes'));
+
+        $match = $router->match($request);
+
+        $this->assertNotNull($match);
+        $this->assertSame('token/with/slashes', $match->getParam('token'));
+    }
+
+    public function testAssembleDoesNotEncodeSegmentWhenDisabled(): void
+    {
+        $router = $this->createRouter([
+            'disable_segment_encoding' => [
+                'token' => true,
+            ],
+        ]);
+
+        $this->assertSame(
+            '/example/route/with/token/with/slashes',
+            $router->assemble(['token' => 'token/with/slashes'], ['name' => 'example-route'])->toString()
+        );
+    }
+
+    public function testMatchDoesNotDecodeSegmentWhenDisabled(): void
+    {
+        $router  = $this->createRouter([
+            'disable_segment_encoding' => [
+                'token' => true,
+            ],
+        ]);
+        $request = (new Request())->withUri(new Uri('http://example.com/example/route/with/token%2Fwith%2Fslashes'));
+
+        $match = $router->match($request);
+
+        $this->assertNotNull($match);
+        $this->assertSame('token%2Fwith%2Fslashes', $match->getParam('token'));
+    }
+
+    /**
+     * Explicitly setting the option to `false` must behave identically to
+     * omitting it: encoding stays enabled.
+     */
+    public function testAssembleEncodesSegmentWhenExplicitlyEnabled(): void
+    {
+        $router = $this->createRouter([
+            'disable_segment_encoding' => [
+                'token' => false,
+            ],
+        ]);
+
+        $this->assertSame(
+            '/example/route/with/token%2Fwith%2Fslashes',
+            $router->assemble(['token' => 'token/with/slashes'], ['name' => 'example-route'])->toString()
+        );
+    }
+}


### PR DESCRIPTION
Add `disable_segment_encoding` option to `Segment`

- Introduce the `disable_segment_encoding` option to control URL encoding at the segment level.
- Update `Segment` logic to respect encoding options during `assemble` and `match`.
- Add `isSegmentEncodingEnabled` method for parameter-specific encoding checks.
- Include test coverage to validate `disable_segment_encoding` behavior.
- Enhance documentation to explain the usage and impact of this feature.